### PR TITLE
Add Lisa's Tapistry to the portfolio and docs hub

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ deployment, and troubleshooting in depth.
 
 ### You're here to play
 
-Kluth Studios ships four browser games and interactive experiences. All of
+Kluth Studios ships five browser games and interactive experiences. All of
 them run instantly in the browser. No install, no account, and free. Pick
 one and go:
 
@@ -34,6 +34,8 @@ one and go:
   arcade climbing platformer.
 - [Lisetris](./lisetris/overview.md) is a romantic neon falling-block puzzle
   game, made for Lisa.
+- [Lisa's Tapistry](./lisas-tapistry/overview.md) is a cozy tap-away mosaic
+  puzzle game, made for Lisa.
 - [Skyroute](./skyroute/overview.md) is SkyRoute Infinite, an open-world
   browser flight simulator.
 - [Spindrift](./spindrift/overview.md) is a vector-style arcade space

--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -5,7 +5,7 @@ description: How kurtkluth.dev is built, and how a new project gets added as a c
 
 This site is a portfolio and a documentation hub in one codebase. Here's how
 it's put together, and what it takes to add a project, which is deliberately
-a content task, not a redesign.
+a small, contained task, mostly content and metadata, not a redesign.
 
 ## The stack
 
@@ -24,19 +24,38 @@ a content task, not a redesign.
 
 ## How a project gets added
 
-Four steps, all content and metadata:
+Six steps. Most of it is content and metadata; two small code files give the
+project its page and its artwork.
 
-1. **Add one entry to `src/data/projects.ts`** with `name`, `slug`, `summary`,
-   `category`, `status`, `liveUrl`, `technologies`, and `accent`. This
-   single record drives everything the portfolio side shows.
-2. **Create `docs/<slug>/` with the minimum page set.** An overview (the
-   entry point), a how-to-play or quick-start, a gameplay or concepts page,
-   tips, an FAQ, and a changelog.
-3. **Register the sidebar group in `sidebars.ts`** so the new section
+1. **Add one entry to `src/data/projects.ts`.** One record with the
+   project's `name`, `slug`, `summary`, `lede`, `category`, `status`,
+   `liveUrl`, `launchLabel`, `docsPath`, `technologies`, `featured`,
+   `accentColor`, `studio`, `highlights`, `gettingStarted`, and `updates`
+   (with `inGameTitle` and `repositoryUrl` optional). This single record
+   drives the homepage grid, the projects index, the About page, and the
+   content of the project detail page.
+2. **Add the detail-page route at `src/pages/projects/<slug>.tsx`.** A short
+   file that renders `<ProjectPage slug="<slug>" />`. The `ProjectPage`
+   component is generic and reads everything from the metadata; this file
+   just gives the project its URL.
+3. **Add a `ProjectArt` scene in `src/components/ProjectArt/index.tsx`.** A
+   self-contained SVG keyed by the slug, used on the card and the hero.
+   Without one, the art frame renders empty.
+4. **Create `docs/<slug>/` with the page set.** An overview (the entry
+   point), a how-to-play or quick-start, a gameplay or concepts page, tips,
+   an FAQ, and a changelog.
+5. **Register the sidebar group in `sidebars.ts`** so the new section
    appears in the docs navigation.
-4. **Done.** The homepage grid, the projects index, and the project detail
-   page all pick the new project up from the metadata automatically. No
-   component edits, no hand-built routes.
+6. **Update the spots that count the projects by hand.** A few places
+   hardcode the total: the homepage terminal comment
+   (`src/pages/index.tsx`), the projects-index lede
+   (`src/pages/projects/index.tsx`), and the docs landing and
+   getting-started pages (`docs/index.md`, `docs/getting-started.md`). The
+   cross-project [How to Play](./how-to-play.md) guide also lists the games.
+   Grep for the current count word and bump it.
+
+After that, the homepage grid, the projects index, and the About page pick
+the new project up from the metadata automatically.
 
 ## How content flows
 
@@ -44,14 +63,19 @@ Four steps, all content and metadata:
 flowchart LR
   P["src/data/projects.ts"] --> HG["Homepage grid"]
   P --> PI["Projects index"]
-  P --> PD["Project detail pages"]
-  D["docs/ content"] --> SB["sidebars.ts"]
+  P --> AB["About page"]
+  P --> PD["Project detail page"]
+  RT["Per-project route file"] --> PD
+  ART["Per-project ProjectArt scene"] --> PD
+  D["Per-project docs folder"] --> SB["sidebars.ts"]
   SB --> NAV["Docs sidebar"]
   D --> SRCH["Local search index"]
 ```
 
-One metadata file feeds the portfolio; the docs folder feeds the sidebar and
-the search index. A project isn't finished until both sides know about it.
+One metadata file feeds most of the portfolio, with a small route file and an
+SVG scene giving each project its own page and artwork; the docs folder feeds
+the sidebar and the search index. A project isn't finished until both sides
+know about it.
 
 ## Conventions worth keeping
 

--- a/docs/guides/how-to-play.md
+++ b/docs/guides/how-to-play.md
@@ -1,6 +1,6 @@
 ---
 title: How to Play
-description: What every Kluth Studios game has in common, a quick launcher for all four, and where to learn each one in depth.
+description: What every Kluth Studios game has in common, a quick launcher for all five, and where to learn each one in depth.
 ---
 
 Every Kluth Studios game follows the same philosophy. Click the link, play
@@ -12,9 +12,9 @@ game's own how-to-play page for the specifics.
 - **Instant browser play.** Open the live URL and you're in. No install, no
   account, no payment, ever.
 - **Keyboard-first, with touch where it fits.** Every game plays great on a
-  keyboard. Lisa Climber, Lisetris, and Spindrift also support touch, so
-  phones and tablets work well. Skyroute has enough controls that it
-  strongly prefers a keyboard.
+  keyboard. Lisa Climber, Lisetris, and Spindrift also support touch, and
+  Lisa's Tapistry is built for touch first, so phones and tablets work
+  well. Skyroute has enough controls that it strongly prefers a keyboard.
 - **Scores and progress live in your browser.** High scores, stats, and
   settings are stored locally on the device you play on; nothing is sent
   to a server.
@@ -37,6 +37,7 @@ cloud sync. Guard the browser that holds your high scores.
 |---|---|---|---|
 | Lisa Climber | Summit Smash, a pixel-art arcade climbing platformer | [lisaclimber.kluthstudios.com](https://lisaclimber.kluthstudios.com) | [Overview](../lisa-climber/overview.md) |
 | Lisetris | A romantic neon falling-block puzzle game, made for Lisa | [lisetris.kluthstudios.com](https://lisetris.kluthstudios.com) | [Overview](../lisetris/overview.md) |
+| Lisa's Tapistry | A cozy tap-away mosaic puzzle, made for Lisa | [tapistry.kluthstudios.com](https://tapistry.kluthstudios.com) | [Overview](../lisas-tapistry/overview.md) |
 | Skyroute | SkyRoute Infinite, an open-world browser flight simulator | [skyroute.kluthstudios.com](https://skyroute.kluthstudios.com) | [Overview](../skyroute/overview.md) |
 | Spindrift | A vector-style arcade space shooter in the Asteroids tradition | [spindrift.kluthstudios.com](https://spindrift.kluthstudios.com) | [Overview](../spindrift/overview.md) |
 
@@ -59,6 +60,16 @@ with `Z`), and hold a piece with `C` or `Shift`. Classic mode speeds up as
 you clear rows until the well tops out; Relaxed mode is exactly what it
 sounds like. Full details:
 [Lisetris How to Play](../lisetris/how-to-play.md).
+
+### Lisa's Tapistry
+
+A cozy tap-away mosaic puzzle. Each level is a grid of arrow tiles over a
+hidden picture; tap a tile when the path ahead of its arrow is clear and it
+slides off, revealing the beads underneath. Clear them all, in the right
+order, to finish the mosaic. It plays with a tap (or arrow keys and `Enter`),
+teaches itself in a short tutorial, and offers three boosters when you are
+stuck. Full details:
+[Lisa's Tapistry How to Play](../lisas-tapistry/how-to-play.md).
 
 ### Skyroute
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ promise lives.
 
 ## The projects
 
-Five projects, one hub. Each name links to that project's overview doc, and
+Six projects, one hub. Each name links to that project's overview doc, and
 each live link opens the real thing.
 
 | Project | One-liner | Live site |
@@ -20,10 +20,11 @@ each live link opens the real thing.
 | [SQLCLR](./sqlclr/overview.md) | Running .NET inside SQL Server. Governed, hardened extensibility at the engine boundary. | [sqlclr.com](https://sqlclr.com) |
 | [Lisa Climber](./lisa-climber/overview.md) | Summit Smash, a pixel-art arcade climbing platformer. Six stages, three hearts, one long way up. | [lisaclimber.kluthstudios.com](https://lisaclimber.kluthstudios.com) |
 | [Lisetris](./lisetris/overview.md) | A romantic neon falling-block puzzle game, made for Lisa. | [lisetris.kluthstudios.com](https://lisetris.kluthstudios.com) |
+| [Lisa's Tapistry](./lisas-tapistry/overview.md) | A cozy tap-away mosaic puzzle. Clear the tiles, reveal the picture. | [tapistry.kluthstudios.com](https://tapistry.kluthstudios.com) |
 | [Skyroute](./skyroute/overview.md) | SkyRoute Infinite, an open-world flight simulator that runs straight from your browser. | [skyroute.kluthstudios.com](https://skyroute.kluthstudios.com) |
 | [Spindrift](./spindrift/overview.md) | A vector-style arcade space shooter with a persistent high score to chase. | [spindrift.kluthstudios.com](https://spindrift.kluthstudios.com) |
 
-SQLCLR is the serious developer tool. The other four are Kluth Studios games
+SQLCLR is the serious developer tool. The other five are Kluth Studios games
 and interactive experiences. All of them are free, all in the browser, with
 no install and no account required.
 

--- a/docs/lisas-tapistry/changelog.md
+++ b/docs/lisas-tapistry/changelog.md
@@ -1,0 +1,53 @@
+---
+title: Changelog
+description: Release notes and status history for Lisa's Tapistry on kurtkluth.dev.
+---
+
+This page records the notable moments in Lisa's Tapistry's life on this
+site, newest first. It is a short page today, with room to grow.
+
+## 2026-07-19: Joined the collection
+
+**Status: Active**
+
+Lisa's Tapistry joined the Kluth Studios collection on kurtkluth.dev.
+
+What arrived with this entry:
+
+- The live game at
+  [tapistry.kluthstudios.com](https://tapistry.kluthstudios.com), a cozy
+  tap-away mosaic puzzle game, free in the browser, mobile-first, and
+  installable as an app.
+- Twelve hand-made levels across three collections, three boosters, and a
+  guided tutorial.
+- A full documentation set for players:
+  - [Overview](./overview.md) covers the game, the one rule, and the collections.
+  - [How to Play](./how-to-play.md) covers the goal, the tiles, and the controls.
+  - [Gameplay](./gameplay.md) explains the collections, hearts, boosters, and scoring.
+  - [Tips](./tips.md) offers practical advice for clearing boards cleanly.
+  - [FAQ](./faq.md) has quick answers, including who Lisa is.
+  - [Changelog](./changelog.md) is this page, ready for whatever comes next.
+- A home on the portfolio: the
+  [Lisa's Tapistry project page](/projects/lisas-tapistry).
+
+## What "Active" means
+
+Active is the healthiest status a project here can have: the game is live,
+playable today, and part of the ongoing collection. When Lisa's Tapistry
+grows, or if anything about its status changes, this page is where it gets
+written down.
+
+:::note
+
+Future updates to the game or its documentation will be recorded here as
+dated entries, newest at the top.
+
+:::
+
+## See also
+
+- [Overview](./overview.md) is the place to start if you have not played yet.
+- [How to Play](./how-to-play.md) gives the one rule and the controls in
+  about two minutes.
+- The [Lisa's Tapistry project page](/projects/lisas-tapistry) shows the
+  game's spot in the collection.

--- a/docs/lisas-tapistry/faq.md
+++ b/docs/lisas-tapistry/faq.md
@@ -1,0 +1,73 @@
+---
+title: FAQ
+description: Quick answers about playing Lisa's Tapistry. Cost, devices, saved progress, hearts, boosters, and Lisa herself.
+---
+
+Quick answers to the questions players actually ask. For the longer
+version, start with the [Overview](./overview.md).
+
+## Is it free?
+
+Yes. Lisa's Tapistry is free to play, with no account, no sign-up, and
+nothing to buy. Coins and boosters are earned in-game and never cost real
+money. It is the same deal as every Kluth Studios game.
+
+## Do I need to install anything?
+
+No. It runs entirely in your browser at
+[tapistry.kluthstudios.com](https://tapistry.kluthstudios.com). Any current
+Chrome, Edge, Firefox, or Safari will do. If you like, you can also install
+it as an app from your browser's menu, and it will work offline after that.
+
+## Does it work on my phone?
+
+Yes, and the phone is where it is happiest. Lisa's Tapistry is built
+mobile-first, with large touch targets and a board that scales to your
+screen in portrait or landscape. It plays just as well on a desktop, with
+full mouse and keyboard support.
+
+## Is my progress saved?
+
+Yes. Your finished levels, stars, best scores, coins, and boosters are all
+stored in your browser, and a level you leave half-finished is saved too,
+so you can close the tab and come back to it later. It stays on the device
+and browser you played in; there is no account or cloud sync, and clearing
+your browser's site data resets it.
+
+## What are hearts for?
+
+In the Little Garden and Cozy Corner, hearts are just for show, and a
+blocked tap costs nothing. In the Wonder Cabinet challenge levels, each
+blocked tap spends a heart, and running out of all three restarts the
+puzzle. The game explains this with a notice before the first challenge
+level, so it never catches you off guard.
+
+## Do I have to use boosters?
+
+No. Every level is designed and checked to be solvable without any
+boosters. They are optional help for when you are stuck, and using one
+costs you the level's third star. See [Tips](./tips.md) for when they are
+worth it.
+
+## Can I turn the sound off?
+
+Yes. Settings has a master sound switch plus separate sound-effects control,
+and the setting is remembered when you come back. The game is fully playable
+with sound off; nothing important is communicated by sound alone.
+
+## Is it accessible?
+
+That was a priority. Lisa's Tapistry plays fully from the keyboard, offers
+reduced-motion and high-contrast options, labels its controls for screen
+readers, and never relies on color alone to tell the arrows apart.
+
+## Who is Lisa?
+
+Lisa is the person the Kluth Studios games are made for. Her name is on this
+one the way it is on Lisetris and Lisa Climber. The puzzle is real, and so
+is the reason for it.
+
+## Keep reading
+
+- [Overview](./overview.md) is the place to start if you have not played yet.
+- [How to Play](./how-to-play.md) gives the one rule and the controls.

--- a/docs/lisas-tapistry/gameplay.md
+++ b/docs/lisas-tapistry/gameplay.md
@@ -1,0 +1,70 @@
+---
+title: Gameplay
+description: The three collections, how hearts and boosters work, stars and coins, and how your progress is saved.
+---
+
+One rule, twelve levels, and a few gentle systems that reward clearing
+boards thoughtfully. Here is how Lisa's Tapistry actually works once you
+are past the tutorial.
+
+## Three collections
+
+The levels are grouped into three collections, unlocked in order as you
+finish them.
+
+- **Lisa's Little Garden.** The introductory puzzles. Small boards, room to
+  breathe, and the place the game teaches you to look for clear paths.
+- **Lisa's Cozy Corner.** Intermediate boards. Tighter arrangements where
+  the order you clear tiles in starts to matter more.
+- **Lisa's Wonder Cabinet.** The largest, most strategic mosaics, and the
+  only place hearts come into play.
+
+Each level, when solved, shows the finished mosaic, your star rating, and
+the coins you earned, with buttons to move on, replay, or return to level
+select.
+
+## Hearts and challenges
+
+In the Garden and Cozy Corner, hearts are just decoration; a blocked tap
+never costs you anything, so you are free to explore the board. In the
+Wonder Cabinet, hearts are real: each blocked tap spends one, and running
+out resets the puzzle. The game shows a clear notice explaining this before
+the first challenge level, so it never surprises you. Careful reading of
+the board is how you keep all three hearts.
+
+## Boosters in depth
+
+Boosters are optional help, never a requirement. Each is limited, shows its
+remaining count, and explains itself the first time you reach for it.
+
+- **Thread Hint** highlights a tile that can be cleared right now. Good when
+  you simply cannot spot a legal move.
+- **Spool Sweep** clears one removable tile for you, with a little flourish
+  of thread. Good for nudging a board forward.
+- **Needle Turn** rotates one stuck tile clockwise until its arrow finds a
+  clear path. Good for a single tile boxed in the wrong direction.
+
+Because every level is solvable without boosters, using one is a
+convenience, not a rescue, though it does cost you the top star.
+
+## Stars and coins
+
+Finishing a level always earns coins and at least one star. Clearing a
+board cleanly, with no blocked taps and no boosters, earns all three stars
+and the best reward. Keeping a winning streak going and finishing
+efficiently add bonus coins. Coins can be spent on more boosters. All of it
+is local and just for fun; there is nothing to buy and nothing to pay.
+
+## Your progress is saved
+
+Lisa's Tapistry remembers everything in your browser: which levels you have
+finished, your stars and best scores, your coins and boosters, and even a
+puzzle you left half-finished. Close the tab in the middle of a level and
+come back later, and it picks up right where you left off. It is all stored
+on your device, with no account and no cloud sync, so it stays on the
+browser you played in.
+
+## Keep reading
+
+- [How to Play](./how-to-play.md) has the one rule and the full controls.
+- [Tips](./tips.md) puts the order, hearts, and boosters to work.

--- a/docs/lisas-tapistry/how-to-play.md
+++ b/docs/lisas-tapistry/how-to-play.md
@@ -1,0 +1,72 @@
+---
+title: How to Play
+description: The goal, the one tile rule, the boosters, and the full controls for playing on touch or keyboard.
+---
+
+Lisa's Tapistry has exactly one rule to learn, and the game teaches it to
+you in a short guided tutorial the first time you play. Here it is in
+writing.
+
+## The goal
+
+Every level covers a hidden mosaic with a grid of arrow tiles. Remove all
+the tiles and you reveal the whole picture. That is the level, cleared.
+
+## When a tile can leave
+
+A tile points up, down, left, or right. It can only be removed when the
+path in front of its arrow is clear all the way to the edge of the board.
+If another tile is anywhere along that path, the tile is blocked.
+
+- **Tap a clear tile** and it slides off the board in the direction it
+  points, revealing the beads underneath.
+- **Tap a blocked tile** and it gives a small wiggle and stays. In the
+  ordinary Garden and Cozy Corner levels this costs you nothing; it is just
+  a nudge that you picked the wrong tile. In Wonder Cabinet challenges it
+  costs a heart.
+
+The skill is order. A tile that is stuck now often frees up once you clear
+the tiles in front of it, so look for the ones that can leave, clear them,
+and watch new paths open.
+
+## The tutorial
+
+The first time you press Play, Lisa's Tapistry runs a four-step tutorial on
+a tiny practice board. It shows you an arrow tile, has you clear one with a
+free path, then shows how clearing in the right order frees a blocked tile,
+and finishes by revealing a little heart. It takes under a minute, and you
+can replay it any time from **Settings**.
+
+## Boosters
+
+Three boosters help when a board has you stuck. Each shows how many you
+have left and explains itself before its first use.
+
+- **Thread Hint** highlights one tile you can clear right now.
+- **Spool Sweep** clears one removable tile for you.
+- **Needle Turn** rotates one stuck tile clockwise until it points toward a
+  clear path, then you tap it to use it.
+
+You earn more boosters as coins add up; nothing is ever required to finish
+a level. [Gameplay](./gameplay.md) covers coins and hearts in full.
+
+## Controls
+
+Lisa's Tapistry is built for touch first, and everything also works from a
+keyboard.
+
+| Action | Touch | Keyboard |
+|---|---|---|
+| Select or clear a tile | Tap the tile | Arrow keys move between tiles, `Enter` or `Space` clears |
+| Use a booster | Tap the booster, then a tile if needed | `Tab` to the booster, `Enter`, then a tile |
+| Pause | Tap the pause button | `Tab` to pause, `Enter` |
+| Close a dialog | Tap outside, or the button | `Esc` |
+
+Touch targets are large, the board scales to fit your screen, and the game
+never relies on color alone to tell arrows apart, so it stays readable in
+high-contrast mode.
+
+## Keep reading
+
+- [Gameplay](./gameplay.md) covers the collections, hearts, boosters, and scoring.
+- [Tips](./tips.md) has practical advice for clearing boards cleanly.

--- a/docs/lisas-tapistry/overview.md
+++ b/docs/lisas-tapistry/overview.md
@@ -1,0 +1,77 @@
+---
+title: Overview
+description: What Lisa's Tapistry is (a cozy tap-away mosaic puzzle game) and what is inside it.
+---
+
+Lisa's Tapistry is a cozy, mobile-first tap-away puzzle game. Every level
+is a grid of little arrow tiles laid over a hidden picture stitched from
+colored beads. Tap a tile when the path ahead of its arrow is clear and it
+slides off the board, uncovering the piece of the mosaic underneath. Clear
+them all, in the right order, and the whole picture appears.
+
+The tagline says the rest: "Tap the path clear. Reveal something
+wonderful."
+
+Play it free at
+[tapistry.kluthstudios.com](https://tapistry.kluthstudios.com), in your
+browser, no install, no account.
+
+## The one rule
+
+Each tile points up, down, left, or right. A tile can leave only when
+nothing stands between it and the edge of the board in the direction it
+points. Tap a tile with a clear path and it flies away; tap a blocked one
+and it just gives a gentle wiggle and stays put. The whole game is reading
+the board and deciding what to clear first. [How to Play](./how-to-play.md)
+walks through it.
+
+## Twelve levels, three collections
+
+The levels are grouped into three collections that build on each other:
+
+- **Lisa's Little Garden** eases you in with small, friendly boards.
+- **Lisa's Cozy Corner** turns up the thinking with tighter tangles.
+- **Lisa's Wonder Cabinet** brings the big mosaics, and its own twist: in
+  these challenge levels a blocked tap costs a heart.
+
+Every level is hand-made and checked to be solvable without spending a
+single booster. More in [Gameplay](./gameplay.md).
+
+## Boosters and hearts
+
+Three boosters are there for when you are stuck: **Thread Hint** points out
+a tile you can clear, **Spool Sweep** clears one for you, and **Needle
+Turn** rotates a stuck tile toward a clear path. Hearts only ever matter in
+the Wonder Cabinet challenges, and the game explains that rule before it
+can cost you anything.
+
+## The look
+
+Lisa's Tapistry has a warm craft-table feel: soft cream backgrounds, berry
+and coral and teal and gold, rounded tiles with a little depth, and
+stitched dashed edges. The pictures underneath are tiny bead-art mosaics of
+cozy things, flowers, a teacup, a butterfly, a bluebird, a lantern. It is
+meant to feel like clearing a workspace to find something someone made by
+hand.
+
+## Made to be comfortable
+
+The game is built mobile-first and plays with a touch, but it also works
+fully from the keyboard, offers reduced-motion and high-contrast options,
+and never needs sound to be understood. It installs as an app and works
+offline. See [Tips](./tips.md) and the [FAQ](./faq.md) for the practical
+details.
+
+## Part of Kluth Studios
+
+Lisa's Tapistry lives under the Kluth Studios banner, Kurt Kluth's home for
+browser games and experiments. See where it sits in the collection on the
+[Lisa's Tapistry project page](/projects/lisas-tapistry).
+
+## Keep reading
+
+- [How to Play](./how-to-play.md) covers the goal, the tiles, and the controls.
+- [Gameplay](./gameplay.md) explains the collections, boosters, hearts, and scoring.
+- [Tips](./tips.md) offers advice for clearing boards cleanly.
+- [FAQ](./faq.md) has quick answers, including who Lisa is.
+- [Changelog](./changelog.md) holds release notes and status.

--- a/docs/lisas-tapistry/tips.md
+++ b/docs/lisas-tapistry/tips.md
@@ -1,0 +1,59 @@
+---
+title: Tips
+description: Practical advice for clearing boards cleanly, saving your hearts, and earning all three stars.
+---
+
+Seven small habits for clearing mosaics cleanly and keeping all three
+stars. None of them require talent, just doing them on purpose.
+
+## Clear the edges first
+
+Tiles on the outside of the board usually have the shortest path to freedom
+and the fewest tiles in their way. Clearing them first tends to open the
+lanes that the inner tiles need. When a board looks knotted, start where it
+is loosest.
+
+## Read the whole arrow, not just the tile
+
+Before you tap, follow the arrow all the way to the edge. If any tile sits
+on that line, this one is blocked, no matter how close it looks to the
+side. Getting into the habit of tracing the path is the single biggest
+jump in skill.
+
+## A stuck tile is a later tile, not a wrong tile
+
+If a tile cannot leave yet, it almost always can once you clear whatever is
+in front of it. Instead of forcing it, ask which tile is blocking it, and
+whether that one can go now. Work backward along the jam.
+
+## In the Wonder Cabinet, look before you tap
+
+Blocked taps cost hearts only in the challenge levels, and there are just
+three hearts. That makes guessing expensive. Slow down, trace paths, and
+only tap a tile you are sure is clear. The mosaics there are bigger, so the
+patience pays off twice.
+
+## Save boosters for genuine stuck points
+
+Every level can be finished without a booster, and using one costs you the
+third star. Treat Thread Hint, Spool Sweep, and Needle Turn as help for the
+moment you truly cannot find a move, not as a way to hurry. An unspent
+booster is a star kept.
+
+## Needle Turn is for the one tile facing the wrong way
+
+When a single tile is boxed in and pointing into a wall, Needle Turn is
+exactly the tool: it rotates the tile until its arrow finds an open path.
+Reach for it when the board is otherwise fine and just one tile is stuck
+the wrong direction.
+
+## Replay for the clean run
+
+A finished level keeps your best result, so there is no cost to replaying a
+board you cleared messily. Once you know the shape of a level, a calm
+second run for all three stars is often easier than it felt the first time.
+
+## Keep reading
+
+- [Gameplay](./gameplay.md) covers the systems these tips lean on.
+- [FAQ](./faq.md) has quick answers about saving, devices, and Lisa.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -57,6 +57,19 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: "Lisa's Tapistry",
+      link: {type: 'doc', id: 'lisas-tapistry/overview'},
+      items: [
+        'lisas-tapistry/overview',
+        'lisas-tapistry/how-to-play',
+        'lisas-tapistry/gameplay',
+        'lisas-tapistry/tips',
+        'lisas-tapistry/faq',
+        'lisas-tapistry/changelog',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Skyroute',
       link: {type: 'doc', id: 'skyroute/overview'},
       items: [

--- a/src/components/ProjectArt/index.tsx
+++ b/src/components/ProjectArt/index.tsx
@@ -156,6 +156,92 @@ function LisetrisArt() {
   );
 }
 
+function LisasTapistryArt() {
+  // The garden-1 tulip mosaic, as [col, row, kind] beads.
+  const cell = 15;
+  const bead = 12;
+  const cols = 8;
+  const P = 'p';
+  const S = 's';
+  const G = 'g';
+  const beads: Array<[number, number, string]> = [
+    [1, 0, P], [3, 0, P], [4, 0, P], [6, 0, P],
+    [1, 1, P], [2, 1, P], [3, 1, P], [4, 1, P], [5, 1, P], [6, 1, P],
+    [2, 2, P], [3, 2, P], [4, 2, P], [5, 2, P],
+    [3, 3, S], [4, 3, S],
+    [0, 4, G], [3, 4, S], [4, 4, S], [7, 4, G],
+    [1, 5, G], [2, 5, G], [3, 5, S], [4, 5, S], [5, 5, G], [6, 5, G],
+    [3, 6, S], [4, 6, S],
+    [3, 7, S], [4, 7, S],
+  ];
+  const fills: Record<string, string> = {p: '#c2477b', s: '#4e8c4e', g: '#5fa05e'};
+  const originX = (400 - (cols * cell - (cell - bead))) / 2;
+  const originY = 50;
+
+  // A cream arrow tile: rounded square plus a bold directional arrow.
+  function Tile({x, y, rotate, color}: {x: number; y: number; rotate: number; color: string}) {
+    return (
+      <g transform={`translate(${x} ${y})`}>
+        <rect width="42" height="42" rx="10" fill="#fbf1de" stroke="#e5d3b8" strokeWidth="2" />
+        <g transform={`rotate(${rotate} 21 21)`}>
+          <path
+            d="M21 9 L33 24 H26.5 V34 H15.5 V24 H9 Z"
+            fill={color}
+            stroke="#4a3b40"
+            strokeWidth="1.6"
+            strokeLinejoin="round"
+          />
+        </g>
+      </g>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 400 225" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <defs>
+        <linearGradient id="tap-bg" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#4a1a33" />
+          <stop offset="1" stopColor="#240b1a" />
+        </linearGradient>
+        <radialGradient id="tap-glow" cx="0.5" cy="0.45" r="0.55">
+          <stop offset="0" stopColor="#e8a93c" stopOpacity="0.3" />
+          <stop offset="1" stopColor="#e8a93c" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="400" height="225" fill="url(#tap-bg)" />
+      <ellipse cx="200" cy="108" rx="150" ry="96" fill="url(#tap-glow)" />
+      {/* stitched border */}
+      <rect
+        x="14"
+        y="14"
+        width="372"
+        height="197"
+        rx="16"
+        fill="none"
+        stroke="rgba(242,117,95,0.5)"
+        strokeWidth="2"
+        strokeDasharray="7 6"
+      />
+      {/* mosaic tulip */}
+      {beads.map(([c, r, kind], i) => (
+        <rect
+          key={i}
+          x={originX + c * cell}
+          y={originY + r * cell}
+          width={bead}
+          height={bead}
+          rx="3.5"
+          fill={fills[kind]}
+        />
+      ))}
+      {/* floating arrow tiles */}
+      <Tile x={36} y={64} rotate={0} color="#2f8f83" />
+      <Tile x={318} y={48} rotate={270} color="#9b7fc7" />
+      <Tile x={322} y={140} rotate={90} color="#f2755f" />
+    </svg>
+  );
+}
+
 function SkyrouteArt() {
   return (
     <svg viewBox="0 0 400 225" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -258,6 +344,7 @@ const ART: Record<string, () => React.ReactNode> = {
   sqlclr: SqlclrArt,
   'lisa-climber': LisaClimberArt,
   lisetris: LisetrisArt,
+  'lisas-tapistry': LisasTapistryArt,
   skyroute: SkyrouteArt,
   spindrift: SpindriftArt,
 };

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -230,6 +230,61 @@ export const PROJECTS: Project[] = [
     ],
   },
   {
+    name: "Lisa's Tapistry",
+    slug: 'lisas-tapistry',
+    summary:
+      'A cozy tap-away mosaic puzzle in the browser. Clear the tiles, reveal the picture.',
+    lede:
+      'A cozy, mobile-first tap-away puzzle game. Every level hides a little stitched mosaic under a grid of arrow tiles. Tap a tile when the path ahead of its arrow is clear and it slides away, uncovering the picture beneath. Twelve hand-made levels, three boosters, and a warm craft-table look. Tap the path clear, reveal something wonderful.',
+    category: 'Game',
+    status: 'Active',
+    liveUrl: 'https://tapistry.kluthstudios.com',
+    launchLabel: "Play Lisa's Tapistry",
+    docsPath: '/docs/lisas-tapistry/overview',
+    technologies: ['TypeScript', 'Next.js', 'PWA', 'Web'],
+    featured: true,
+    accentColor: '#f2755f',
+    studio: 'Kluth Studios',
+    highlights: [
+      {
+        title: 'Twelve levels, three collections',
+        body: "Lisa's Little Garden eases you in, Cozy Corner turns up the thinking, and Wonder Cabinet brings the big, tricky mosaics. Every level is hand-made and guaranteed solvable.",
+      },
+      {
+        title: 'One satisfying mechanic',
+        body: 'Tap a tile and it flies off the board when its arrow has a clear path, revealing a piece of the hidden mosaic. Blocked tiles just wiggle and wait. The whole game is reading the board and clearing in the right order.',
+      },
+      {
+        title: 'Boosters and hearts',
+        body: 'Three boosters help when you are stuck: Thread Hint, Spool Sweep, and Needle Turn. Hearts only ever matter in the Wonder Cabinet challenges, and the rule is explained before it counts.',
+      },
+      {
+        title: 'Cozy, accessible, installable',
+        body: 'A warm craft-table look with beads, thread, and stitched edges. Full keyboard play, reduced-motion and high-contrast options, and it installs as an app and works offline.',
+      },
+    ],
+    gettingStarted: [
+      {
+        title: 'Open the game',
+        body: "Lisa's Tapistry runs in your browser, free, with nothing to install and no account. It is happiest on a phone but plays anywhere.",
+      },
+      {
+        title: 'Play the tutorial',
+        body: 'A short guided puzzle teaches the one rule in under a minute. You can replay it any time from Settings.',
+      },
+      {
+        title: 'Clear the path',
+        body: 'Work through the collections, earn stars and coins, and uncover every mosaic. The how-to-play doc has the details.',
+      },
+    ],
+    updates: [
+      {
+        date: '2026-07-19',
+        text: 'joined the Kluth Studios collection on kurtkluth.dev.',
+      },
+    ],
+  },
+  {
     name: 'Skyroute',
     inGameTitle: 'SkyRoute Infinite',
     slug: 'skyroute',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,7 @@ function HeroTerminal() {
           </div>
         ))}
         <div className={styles.terminalComment}>
-          # five projects · one home · docs included
+          # six projects · one home · docs included
         </div>
       </div>
     </div>

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -20,7 +20,7 @@ export default function ProjectsIndex(): React.ReactNode {
               as="h1"
               overline="Projects"
               title="Everything, in one place"
-              lede="Five projects, each with a live site and its own documentation. Launch anything; read how it works."
+              lede="Six projects, each with a live site and its own documentation. Launch anything; read how it works."
             />
           </div>
         </header>

--- a/src/pages/projects/lisas-tapistry.tsx
+++ b/src/pages/projects/lisas-tapistry.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ProjectPage from '@site/src/components/ProjectPage';
+
+export default function LisasTapistryProject(): React.ReactNode {
+  return <ProjectPage slug="lisas-tapistry" />;
+}


### PR DESCRIPTION
Adds Lisa'"'"'s Tapistry, a cozy tap-away mosaic puzzle game, as the sixth project on kurtkluth.dev. Documented the same way as the other five games.

## Portfolio
- New `src/data/projects.ts` entry (Game, Active, live at `tapistry.kluthstudios.com`), placed with the Lisa-named games
- Detail-page route at `src/pages/projects/lisas-tapistry.tsx`
- Original `ProjectArt` scene: a mosaic tulip in beads with floating arrow tiles, in the game'"'"'s craft palette

## Docs
- Full six-page set under `docs/lisas-tapistry/` (overview, how-to-play, gameplay, tips, faq, changelog)
- Sidebar category block in `sidebars.ts`

## Counts and cross-links
- Bumped the hardcoded project/game totals on the home terminal, projects index lede, docs landing table, getting-started, and the cross-project how-to-play launcher

## Developer guide correction
- Rewrote "how a project gets added" to reflect reality: the per-project route file, the `ProjectArt` scene, and the manual count updates are now documented as real steps (previously it claimed four steps with "no component edits, no hand-built routes")
- Fixed the field list (`accentColor` and the full required set) and updated the content-flow diagram

Production `docusaurus build` passes (so no broken internal links), and every new/changed surface was verified in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)