### PR TITLE
Add Lisa's Hexscape to the portfolio and docs hub

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ deployment, and troubleshooting in depth.
 
 ### You're here to play
 
-Kluth Studios ships five browser games and interactive experiences. All of
+Kluth Studios ships six browser games and interactive experiences. All of
 them run instantly in the browser. No install, no account, and free. Pick
 one and go:
 
@@ -36,6 +36,8 @@ one and go:
   game, made for Lisa.
 - [Lisa's Tapistry](./lisas-tapistry/overview.md) is a cozy tap-away mosaic
   puzzle game, made for Lisa.
+- [Lisa's Hexscape](./lisas-hexscape/overview.md) is a strategic hexagon
+  puzzle in a twilight garden, made for Lisa.
 - [Skyroute](./skyroute/overview.md) is SkyRoute Infinite, an open-world
   browser flight simulator.
 - [Spindrift](./spindrift/overview.md) is a vector-style arcade space

--- a/docs/guides/how-to-play.md
+++ b/docs/guides/how-to-play.md
@@ -1,6 +1,6 @@
 ---
 title: How to Play
-description: What every Kluth Studios game has in common, a quick launcher for all five, and where to learn each one in depth.
+description: What every Kluth Studios game has in common, a quick launcher for all six, and where to learn each one in depth.
 ---
 
 Every Kluth Studios game follows the same philosophy. Click the link, play
@@ -13,8 +13,9 @@ game's own how-to-play page for the specifics.
   account, no payment, ever.
 - **Keyboard-first, with touch where it fits.** Every game plays great on a
   keyboard. Lisa Climber, Lisetris, and Spindrift also support touch, and
-  Lisa's Tapistry is built for touch first, so phones and tablets work
-  well. Skyroute has enough controls that it strongly prefers a keyboard.
+  Lisa's Tapistry and Lisa's Hexscape are built for touch first, so phones
+  and tablets work well. Skyroute has enough controls that it strongly
+  prefers a keyboard.
 - **Scores and progress live in your browser.** High scores, stats, and
   settings are stored locally on the device you play on; nothing is sent
   to a server.
@@ -38,6 +39,7 @@ cloud sync. Guard the browser that holds your high scores.
 | Lisa Climber | Summit Smash, a pixel-art arcade climbing platformer | [lisaclimber.kluthstudios.com](https://lisaclimber.kluthstudios.com) | [Overview](../lisa-climber/overview.md) |
 | Lisetris | A romantic neon falling-block puzzle game, made for Lisa | [lisetris.kluthstudios.com](https://lisetris.kluthstudios.com) | [Overview](../lisetris/overview.md) |
 | Lisa's Tapistry | A cozy tap-away mosaic puzzle, made for Lisa | [tapistry.kluthstudios.com](https://tapistry.kluthstudios.com) | [Overview](../lisas-tapistry/overview.md) |
+| Lisa's Hexscape | A strategic hexagon puzzle in a twilight garden, made for Lisa | [hexscape.kluthstudios.com](https://hexscape.kluthstudios.com) | [Overview](../lisas-hexscape/overview.md) |
 | Skyroute | SkyRoute Infinite, an open-world browser flight simulator | [skyroute.kluthstudios.com](https://skyroute.kluthstudios.com) | [Overview](../skyroute/overview.md) |
 | Spindrift | A vector-style arcade space shooter in the Asteroids tradition | [spindrift.kluthstudios.com](https://spindrift.kluthstudios.com) | [Overview](../spindrift/overview.md) |
 
@@ -70,6 +72,16 @@ order, to finish the mosaic. It plays with a tap (or arrow keys and `Enter`),
 teaches itself in a short tutorial, and offers three boosters when you are
 stuck. Full details:
 [Lisa's Tapistry How to Play](../lisas-tapistry/how-to-play.md).
+
+### Lisa's Hexscape
+
+A strategic hexagon puzzle in an enchanted twilight garden. Every hex tile
+points at one of its six neighbors; tap it when its path off the board is
+clear and it slides away. Later gardens add colored gates that only accept
+matching tiles, plus frost, switches, and turning hexes. Thirty levels,
+a deterministic daily puzzle, and full keyboard play (arrow keys walk the
+grid, `Enter` clears). It teaches itself in a one-minute tutorial. Full
+details: [Lisa's Hexscape How to Play](../lisas-hexscape/how-to-play.md).
 
 ### Skyroute
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ promise lives.
 
 ## The projects
 
-Six projects, one hub. Each name links to that project's overview doc, and
+Seven projects, one hub. Each name links to that project's overview doc, and
 each live link opens the real thing.
 
 | Project | One-liner | Live site |
@@ -21,10 +21,11 @@ each live link opens the real thing.
 | [Lisa Climber](./lisa-climber/overview.md) | Summit Smash, a pixel-art arcade climbing platformer. Six stages, three hearts, one long way up. | [lisaclimber.kluthstudios.com](https://lisaclimber.kluthstudios.com) |
 | [Lisetris](./lisetris/overview.md) | A romantic neon falling-block puzzle game, made for Lisa. | [lisetris.kluthstudios.com](https://lisetris.kluthstudios.com) |
 | [Lisa's Tapistry](./lisas-tapistry/overview.md) | A cozy tap-away mosaic puzzle. Clear the tiles, reveal the picture. | [tapistry.kluthstudios.com](https://tapistry.kluthstudios.com) |
+| [Lisa's Hexscape](./lisas-hexscape/overview.md) | A strategic hexagon puzzle in a twilight garden. Follow the arrows, find your way out. | [hexscape.kluthstudios.com](https://hexscape.kluthstudios.com) |
 | [Skyroute](./skyroute/overview.md) | SkyRoute Infinite, an open-world flight simulator that runs straight from your browser. | [skyroute.kluthstudios.com](https://skyroute.kluthstudios.com) |
 | [Spindrift](./spindrift/overview.md) | A vector-style arcade space shooter with a persistent high score to chase. | [spindrift.kluthstudios.com](https://spindrift.kluthstudios.com) |
 
-SQLCLR is the serious developer tool. The other five are Kluth Studios games
+SQLCLR is the serious developer tool. The other six are Kluth Studios games
 and interactive experiences. All of them are free, all in the browser, with
 no install and no account required.
 

--- a/docs/lisas-hexscape/changelog.md
+++ b/docs/lisas-hexscape/changelog.md
@@ -1,0 +1,62 @@
+---
+title: Changelog
+description: Release notes and status history for Lisa's Hexscape on kurtkluth.dev.
+---
+
+This page records the notable moments in Lisa's Hexscape's life on this
+site, newest first. It arrived all at once, so today there are two.
+
+## 2026-07-19: Went live
+
+**Status: Active**
+
+Lisa's Hexscape went live at
+[hexscape.kluthstudios.com](https://hexscape.kluthstudios.com). The game
+is now playable in the browser, mobile-first and installable as an app,
+and the Play and live-site links across kurtkluth.dev resolve to the real
+thing.
+
+## 2026-07-19: Joined the collection
+
+**Status: Active**
+
+Lisa's Hexscape joined the Kluth Studios collection on kurtkluth.dev as
+its seventh project.
+
+What arrived with this entry:
+
+- The game itself: a strategic hexagonal tap-away puzzle in an enchanted
+  twilight garden, with 30 solver-verified levels across three chapters,
+  colored garden gates, six obstacle types, four boosters, and a
+  deterministic Daily Bloom puzzle.
+- A full documentation set for players:
+  - [Overview](./overview.md) covers the game, the one rule, and the chapters.
+  - [How to Play](./how-to-play.md) covers the goal, gates, moves, and controls.
+  - [Gameplay](./gameplay.md) explains chapters, obstacles, stars, and the daily.
+  - [Tips](./tips.md) offers practical advice for three-star runs.
+  - [FAQ](./faq.md) has quick answers, including who Lisa is.
+  - [Changelog](./changelog.md) is this page, ready for whatever comes next.
+- A home on the portfolio: the
+  [Lisa's Hexscape project page](/projects/lisas-hexscape).
+
+## What "Active" means
+
+Active is the healthiest status a project here can have: the game is live,
+playable today, and part of the ongoing collection. When Lisa's Hexscape
+grows, or if anything about its status changes, this page is where it gets
+written down.
+
+:::note
+
+Future updates to the game or its documentation will be recorded here as
+dated entries, newest at the top.
+
+:::
+
+## See also
+
+- [Overview](./overview.md) is the place to start if you have not played yet.
+- [How to Play](./how-to-play.md) gives the one rule and the controls in
+  about two minutes.
+- The [Lisa's Hexscape project page](/projects/lisas-hexscape) shows the
+  game's spot in the collection.

--- a/docs/lisas-hexscape/faq.md
+++ b/docs/lisas-hexscape/faq.md
@@ -1,0 +1,78 @@
+---
+title: FAQ
+description: Quick answers about playing Lisa's Hexscape. Cost, devices, saving, the daily puzzle, boosters, and Lisa herself.
+---
+
+Quick answers to the questions players actually ask. For the longer
+version, start with the [Overview](./overview.md).
+
+## Is it free?
+
+Yes. Lisa's Hexscape is free to play, with no account, no sign-up, and
+nothing to buy. Flower tokens are earned in-game, spent only on boosters,
+and never cost real money. It is the same deal as every Kluth Studios
+game.
+
+## Do I need to install anything?
+
+No. It runs entirely in your browser at
+[hexscape.kluthstudios.com](https://hexscape.kluthstudios.com). Any
+current Chrome, Edge, Firefox, or Safari will do. If you like, install it
+as an app from your browser's menu and it will keep working offline.
+
+## Does it work on my phone?
+
+Yes. It is built mobile-first with large touch targets, safe-area
+handling, and portrait and landscape layouts, and it plays equally well on
+a desktop with mouse or keyboard.
+
+## Is my progress saved?
+
+Yes. Unlocked levels, stars, best move counts, tokens, boosters, settings,
+daily history, and any half-finished puzzle are stored in your browser. A
+level you abandon mid-way resumes exactly where you left it. Everything
+stays on the device and browser you played in; clearing the browser's site
+data resets it, and there is no account or cloud sync.
+
+## What happens when I run out of moves?
+
+Only challenge levels have move limits, and running out simply shows a
+retry screen: restart free, or spend an Extra Moves booster for five more.
+Nothing is lost but the attempt, and relaxed levels never end at all.
+
+## Is the daily puzzle the same for everyone?
+
+Yes. The Daily Bloom is generated from the date, so the same local date
+produces the same board everywhere, and it is guaranteed solvable.
+Completion is recorded on your device only; there is no online leaderboard,
+so the only bragging rights are the ones you tell people about yourself.
+
+## Do I have to use boosters?
+
+No. Every level is verified solvable without any boosters before it ships.
+They are optional help, and using one costs the level's third star. See
+[Tips](./tips.md) for when they earn their keep.
+
+## Can I turn the sound off?
+
+Yes. Settings has a master sound switch (also available from the pause
+menu), plus a separate sound-effects control, and the setting survives
+reloads. Nothing in the game is communicated by sound alone.
+
+## Is it accessible?
+
+That was a priority. Full keyboard play (the four arrow keys navigate the
+hex grid), screen-reader labels on every hex and control, a Color
+Assistance mode that adds letter badges to colored tiles, high contrast
+and reduced motion modes, and no reliance on hover, haptics, or sound.
+
+## Who is Lisa?
+
+Lisa is the person the Kluth Studios games are made for. Her name is on
+this one the way it is on Lisetris, Lisa Climber, and Lisa's Tapistry. The
+puzzle is real, and so is the reason for it.
+
+## Keep reading
+
+- [Overview](./overview.md) is the place to start if you have not played yet.
+- [How to Play](./how-to-play.md) gives the one rule and the controls.

--- a/docs/lisas-hexscape/gameplay.md
+++ b/docs/lisas-hexscape/gameplay.md
@@ -1,0 +1,72 @@
+---
+title: Gameplay
+description: The three chapters, all six obstacles, stars and flower tokens, the Daily Bloom, and how progress is saved.
+---
+
+One rule, six directions, and a garden that keeps finding new ways to ask
+the same question: what order do these tiles want to leave in?
+
+## Three chapters
+
+- **Lisa's Twilight Trail.** Ten levels of pure directional play. The early
+  boards are gentle; the later ones introduce move limits with room to
+  spare.
+- **Lisa's Moonlit Garden.** Ten levels that add colored garden gates,
+  stone hexes, and frosted tiles, on bigger boards with tighter sequences.
+- **Lisa's Starlight Summit.** Ten levels of turning hexes, flower
+  switches, hanging tiles, numbered locks, and the tightest move budgets in
+  the game.
+
+Levels unlock in order. Finishing a level records your stars and best move
+count, and replaying a finished level any time is free practice; your best
+result always stands.
+
+## The obstacles
+
+Each obstacle introduces itself with a short notice the first time you meet
+it, before it can cost you anything.
+
+- **Stone Hex.** Never moves. Levels complete around stones, not through
+  them.
+- **Frosted Hex.** An arrow tile under one or two layers of frost. Tap it
+  to break a layer (that costs a move); once thawed it moves normally.
+- **Turning Hex.** Tap it to rotate every neighboring arrow one step
+  clockwise. It costs a move, stays on the board, and can be used again;
+  sometimes the only way out is to spin a stuck tile toward daylight.
+- **Flower Switch.** Tap it to open or close every garden gate of its
+  color. Some gates start closed, and the switch is the only key.
+- **Hanging Hex.** Held by the tiles above it. Clear both upper neighbors
+  and it swings free.
+- **Numbered Hex.** Shows a countdown that drops each time a neighboring
+  tile is removed. At zero it unlocks and plays like any other tile.
+
+## Stars and flower tokens
+
+Every level has a **par**, the move count of a known clean solution.
+Finish at or under par without boosters for three stars; within three
+moves of par for two; finishing at all always earns one. Stars and best
+move counts are recorded per level, and completions pay flower tokens,
+with better runs paying more. Tokens buy extra boosters and nothing else;
+there is no real money anywhere in the game.
+
+## The Daily Bloom
+
+Once a day, the garden grows one fresh challenge puzzle from the date
+itself. The same local date produces the same board for every player, and
+the generator only places tiles where they could escape, so every daily is
+solvable by construction. Finishing pays a bonus ten tokens and marks the
+day complete on your device. A new bloom opens at midnight, local time.
+
+## Your progress is saved
+
+Everything lives in your browser: unlocked levels, stars, best move
+counts, tokens, boosters, settings, daily history, and even a puzzle you
+leave half-finished. The game stores your actual moves and replays them,
+so an interrupted level comes back exactly as you left it, undo included.
+There is no account and no cloud sync; it stays on the device you played
+on.
+
+## Keep reading
+
+- [How to Play](./how-to-play.md) has the one rule and the full controls.
+- [Tips](./tips.md) turns the obstacle rules into strategy.

--- a/docs/lisas-hexscape/how-to-play.md
+++ b/docs/lisas-hexscape/how-to-play.md
@@ -1,0 +1,78 @@
+---
+title: How to Play
+description: The goal, the six directions, gates and move limits, and the full controls for touch, mouse, and keyboard.
+---
+
+Lisa's Hexscape teaches itself in a three-part interactive tutorial the
+first time you press Play. Here is the same lesson in writing.
+
+## The goal
+
+Every level is a hexagonal board of arrow tiles. Remove them all and the
+level is cleared. Some hexes (stones, turning hexes, flower switches) are
+permanent fixtures; the level completes when every removable tile is gone.
+
+## When a tile can leave
+
+A tile's arrow points at one of its six neighboring directions: left,
+right, upper-left, upper-right, lower-left, or lower-right. It can leave
+only when the straight line from the tile, in that direction, is clear all
+the way off the board.
+
+- **Tap a clear tile** and it slides away in the direction it points.
+- **Tap a blocked tile** and it gives a small wiggle and stays. Blocked
+  taps never cost a move; they are a free nudge that you picked the wrong
+  tile.
+
+Clearing one tile often frees others, so the game is really about order.
+Look for what can leave now, and think about what each removal unlocks.
+
+## Garden gates
+
+Some gardens in the Moonlit chapter and beyond have colored gates on their
+edges, listed above the board with their direction and open or closed
+state. In a gated garden a tile may only leave through a gate of its own
+color, so a coral tile pointing at a turquoise gate is just as stuck as a
+blocked one. Flower switches on the board open and close the gates of
+their color.
+
+## Relaxed and challenge levels
+
+- **Relaxed** levels have no move limit, and the undo button lets you take
+  back as many moves as you like.
+- **Challenge** levels show a move budget ("Moves 3 of 9"). Every removal,
+  frost strike, turner activation, and switch flip costs one move; blocked
+  taps stay free. Run out and a retry screen offers a restart or the Extra
+  Moves booster. There are no timers, hidden or otherwise.
+
+## Boosters
+
+Four boosters help when you are stuck. Each shows how many you have left,
+explains itself before its first use, and can be bought with flower tokens
+when you run out.
+
+- **Lisa's Lantern** lights up one tile that can leave right now.
+- **Petal Turn** rotates one tile clockwise by a single hex direction.
+- **Starburst** clears one removable tile, or breaks one frost layer.
+- **Extra Moves** adds five moves in a challenge level.
+
+Every level is solvable without them, and using one costs the third star.
+
+## Controls
+
+| Action | Touch / mouse | Keyboard |
+|---|---|---|
+| Clear or activate a hex | Tap or click it | Arrow keys move between hexes, `Enter` or `Space` activates |
+| Use a booster | Tap the booster, then a glowing hex if asked | `Tab` to the booster, `Enter`, then a hex |
+| Undo (relaxed levels) | Tap the undo arrow | `Tab` to undo, `Enter` |
+| Pause | Tap the pause button | `Tab` to pause, `Enter` |
+| Close a dialog | Tap outside, or the button | `Esc` |
+
+The four arrow keys walk the six-direction grid by moving focus to the
+nearest hex in that screen direction, so every board is fully playable
+without a pointer.
+
+## Keep reading
+
+- [Gameplay](./gameplay.md) covers chapters, obstacles, stars, and the Daily Bloom.
+- [Tips](./tips.md) has practical advice for keeping all three stars.

--- a/docs/lisas-hexscape/overview.md
+++ b/docs/lisas-hexscape/overview.md
@@ -1,0 +1,82 @@
+---
+title: Overview
+description: What Lisa's Hexscape is (a strategic hexagon puzzle in a twilight garden) and what is inside it.
+---
+
+Lisa's Hexscape is a strategic tap-away puzzle set in an enchanted twilight
+garden. Every level is a hexagonal board of softly glowing tiles, and every
+tile carries an arrow pointing at one of its six neighbors. Tap a tile when
+the path ahead of its arrow is clear and it slides off the board; tap one
+that is blocked and it just wiggles and waits. Clear every tile, in the
+right order, and the path out of the garden is yours.
+
+The tagline is the whole strategy guide in eight words: "Follow the arrows.
+Find your way out."
+
+Play it free at
+[hexscape.kluthstudios.com](https://hexscape.kluthstudios.com), in your
+browser, no install, no account.
+
+## The one rule, six ways
+
+Hexagons make this trickier than it sounds. Arrows can point left, right,
+upper-left, upper-right, lower-left, or lower-right, so every tile has six
+possible escape lines and every line can be blocked by something else you
+have not cleared yet. The skill is reading the board: what is free right
+now, what frees up next, and what order unknots the whole thing.
+[How to Play](./how-to-play.md) walks through it.
+
+## Thirty levels, three chapters
+
+- **Lisa's Twilight Trail** teaches the arrows on small, friendly boards.
+- **Lisa's Moonlit Garden** adds colored garden gates, stones, and frost.
+- **Lisa's Starlight Summit** brings switches, turning hexes, hanging tiles,
+  numbered locks, and tight move limits.
+
+Every level is hand-made and machine-verified: a solver proves each one can
+be finished at par, within its move limit, without spending a single
+booster. More in [Gameplay](./gameplay.md).
+
+## Gates, obstacles, and boosters
+
+In gated gardens, a tile may only leave through a gate of its own color, so
+direction and color both matter. Six obstacle types join gradually, each
+introducing itself before it can cost you anything. Four boosters (Lisa's
+Lantern, Petal Turn, Starburst, and Extra Moves) are there for genuinely
+stuck moments, and every level is solvable without them.
+
+## The Daily Bloom
+
+Once a day the garden grows a fresh puzzle from the date itself. The same
+local date produces the same board for everyone, it is guaranteed solvable
+by the way it is built, and finishing it pays a small token bonus. It lives
+alongside the campaign, not inside it.
+
+## The look
+
+Deep plum and midnight blue, tiles in coral, turquoise, berry, gold, mint,
+and lilac, fireflies drifting over hillside silhouettes, and a five-petal
+flower in the logo. Everything glows a little, nothing shouts.
+
+## Made to be comfortable
+
+Lisa's Hexscape plays with a tap or a mouse, and fully from the keyboard
+(the four arrow keys walk the six-direction grid). Color Assistance adds
+letter badges so color is never the only signal, high contrast and reduced
+motion are one switch away, and the game never needs sound to be understood.
+It installs as an app and works offline. See [Tips](./tips.md) and the
+[FAQ](./faq.md) for the practical details.
+
+## Part of Kluth Studios
+
+Lisa's Hexscape lives under the Kluth Studios banner, Kurt Kluth's home for
+browser games and experiments. See where it sits in the collection on the
+[Lisa's Hexscape project page](/projects/lisas-hexscape).
+
+## Keep reading
+
+- [How to Play](./how-to-play.md) covers the goal, the tiles, and the controls.
+- [Gameplay](./gameplay.md) explains chapters, gates, obstacles, boosters, and scoring.
+- [Tips](./tips.md) offers advice for clearing boards within par.
+- [FAQ](./faq.md) has quick answers, including who Lisa is.
+- [Changelog](./changelog.md) holds release notes and status.

--- a/docs/lisas-hexscape/tips.md
+++ b/docs/lisas-hexscape/tips.md
@@ -1,0 +1,70 @@
+---
+title: Tips
+description: Practical advice for reading hex boards, saving moves, and earning three stars on every level.
+---
+
+Eight habits for finding the way out cleanly. None of them require talent,
+just doing them on purpose.
+
+## Trace the whole line before you tap
+
+A hex arrow's path runs all the way to the edge of the board, and a tile
+five cells away blocks it just as surely as a neighbor. Follow the line to
+the edge with your eyes first. In challenge levels blocked taps are free,
+but the habit of tracing is what gets you under par.
+
+## Start where the board is loose
+
+Tiles pointing at a nearby edge with nothing in front of them are your
+openers. Clearing the loose outside usually frees the tangled middle, and
+in hex boards the middle is always more tangled than it looks.
+
+## A blocked tile is a question, not a wall
+
+When a tile cannot leave, ask what exactly is in its way, and what that
+blocker needs in turn. Work backward along the jam until you find the tile
+that can move now. Chains three and four tiles deep are normal in the
+later chapters.
+
+## In gated gardens, read color first
+
+Before anything else, match each tile's color against the gate in its
+arrow's direction. A tile aimed at the wrong color gate is stuck no matter
+how clear its path is, and spotting that early changes your whole plan.
+Check whether a flower switch controls the gate you need, and remember the
+flip costs a move.
+
+## Spend turner moves deliberately
+
+A turning hex rotates all its arrow-bearing neighbors at once, so look at
+every neighbor before you tap, not just the tile you want to fix. Wrong
+timing can point a tile somewhere it can never leave, and in a challenge
+level each spin costs a move. Sometimes the right play is clearing a
+neighbor first so the turner touches only the tile you mean to turn.
+
+## Break frost early, not eventually
+
+Each frost layer costs a move whenever you break it, so the cost is fixed;
+what changes is flexibility. A thawed tile is one more option on the
+board, and options are how you avoid wasted moves later.
+
+## Save boosters for real knots
+
+Every level is solvable without boosters, and using one forfeits the third
+star. Reach for Lisa's Lantern when you truly cannot find a legal move,
+Petal Turn when exactly one tile faces the wrong way, and Starburst when
+one stubborn hex is holding a whole line hostage. An unspent booster is a
+star kept.
+
+## Use relaxed levels and replays as a practice room
+
+Relaxed levels allow unlimited undo; use it to experiment with orders
+until the pattern clicks. Finished levels replay freely and your best
+result always stands, so a calm second run at three stars costs nothing.
+The Daily Bloom is a fine warm-up too; it never uses obstacles, just pure
+order-reading.
+
+## Keep reading
+
+- [Gameplay](./gameplay.md) covers the systems these tips lean on.
+- [FAQ](./faq.md) has quick answers about saving, devices, and Lisa.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -70,6 +70,19 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: "Lisa's Hexscape",
+      link: {type: 'doc', id: 'lisas-hexscape/overview'},
+      items: [
+        'lisas-hexscape/overview',
+        'lisas-hexscape/how-to-play',
+        'lisas-hexscape/gameplay',
+        'lisas-hexscape/tips',
+        'lisas-hexscape/faq',
+        'lisas-hexscape/changelog',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Skyroute',
       link: {type: 'doc', id: 'skyroute/overview'},
       items: [

--- a/src/components/ProjectArt/index.tsx
+++ b/src/components/ProjectArt/index.tsx
@@ -242,6 +242,89 @@ function LisasTapistryArt() {
   );
 }
 
+function LisasHexscapeArt() {
+  // Pointy-top hexagon points around a center.
+  function hexPoints(cx: number, cy: number, r: number): string {
+    const pts: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const a = (Math.PI / 180) * (60 * i - 90);
+      pts.push(`${(cx + r * Math.cos(a)).toFixed(1)},${(cy + r * Math.sin(a)).toFixed(1)}`);
+    }
+    return pts.join(' ');
+  }
+
+  // Bold arrow glyph rotated toward a hex direction (degrees from up).
+  function Arrow({ cx, cy, rotate }: { cx: number; cy: number; rotate: number }) {
+    const s = 0.62;
+    return (
+      <g transform={`translate(${cx} ${cy}) rotate(${rotate}) scale(${s})`}>
+        <path
+          d="M0 -26 L22 4 H9 V26 H-9 V4 H-22 Z"
+          fill="rgba(23,14,34,0.85)"
+          stroke="#f3ecfa"
+          strokeWidth="4"
+          strokeLinejoin="round"
+        />
+      </g>
+    );
+  }
+
+  const tiles: Array<{ x: number; y: number; r: number; fill: string; rotate?: number }> = [
+    { x: 160, y: 78, r: 42, fill: '#f2755f', rotate: 270 },
+    { x: 233, y: 78, r: 42, fill: '#35b5ab', rotate: 90 },
+    { x: 123, y: 141, r: 42, fill: '#e8b73c', rotate: 150 },
+    { x: 196, y: 141, r: 42, fill: '#d1567f', rotate: 30 },
+    { x: 269, y: 141, r: 42, fill: '#7fd8a4', rotate: 210 },
+  ];
+
+  return (
+    <svg viewBox="0 0 400 225" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <defs>
+        <linearGradient id="hx-bg" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#3a2454" />
+          <stop offset="1" stopColor="#170e22" />
+        </linearGradient>
+        <radialGradient id="hx-glow" cx="0.5" cy="0.45" r="0.55">
+          <stop offset="0" stopColor="#b79ce8" stopOpacity="0.22" />
+          <stop offset="1" stopColor="#b79ce8" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="400" height="225" fill="url(#hx-bg)" />
+      <ellipse cx="200" cy="110" rx="160" ry="100" fill="url(#hx-glow)" />
+      {/* hillside silhouette */}
+      <path d="M0 225V196c40-14 78-30 128-24 56 7 96 24 150 18 46-5 90-16 122-10v45z" fill="#120a1c" opacity="0.8" />
+      {/* faint empty cells */}
+      <polygon points={hexPoints(87, 78, 42)} fill="rgba(183,156,232,0.08)" stroke="#514066" strokeWidth="1.5" />
+      <polygon points={hexPoints(306, 78, 42)} fill="rgba(183,156,232,0.08)" stroke="#514066" strokeWidth="1.5" />
+      {/* arrow tiles */}
+      {tiles.map((t, i) => (
+        <g key={i}>
+          <polygon points={hexPoints(t.x, t.y, t.r)} fill={t.fill} stroke="#514066" strokeWidth="3" />
+          {t.rotate !== undefined ? <Arrow cx={t.x} cy={t.y} rotate={t.rotate} /> : null}
+        </g>
+      ))}
+      {/* fireflies */}
+      <g fill="#e8b73c">
+        <circle cx="48" cy="42" r="2.6" />
+        <circle cx="352" cy="36" r="2.2" opacity="0.8" />
+        <circle cx="330" cy="180" r="2.2" opacity="0.7" />
+        <circle cx="66" cy="176" r="2" opacity="0.6" fill="#7fd8a4" />
+      </g>
+      <text
+        x="200"
+        y="212"
+        textAnchor="middle"
+        fontFamily="JetBrains Mono Variable, monospace"
+        fontSize="10"
+        letterSpacing="4"
+        fill="rgba(184,169,204,0.75)"
+      >
+        FOLLOW THE ARROWS
+      </text>
+    </svg>
+  );
+}
+
 function SkyrouteArt() {
   return (
     <svg viewBox="0 0 400 225" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -345,6 +428,7 @@ const ART: Record<string, () => React.ReactNode> = {
   'lisa-climber': LisaClimberArt,
   lisetris: LisetrisArt,
   'lisas-tapistry': LisasTapistryArt,
+  'lisas-hexscape': LisasHexscapeArt,
   skyroute: SkyrouteArt,
   spindrift: SpindriftArt,
 };

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -285,6 +285,69 @@ export const PROJECTS: Project[] = [
     ],
   },
   {
+    name: "Lisa's Hexscape",
+    slug: 'lisas-hexscape',
+    summary:
+      'A hexagonal tap-away puzzle in a twilight garden. Follow the arrows, find your way out.',
+    lede:
+      'A strategic hexagon puzzle set in an enchanted twilight garden. Every tile points to one of six neighbors; tap it when its path is clear and it slides away. Plan the order, match tiles to colored garden gates, thaw frost, spin turning hexes, and clear all 30 hand-made levels, plus a fresh deterministic daily puzzle. Follow the arrows. Find your way out.',
+    category: 'Game',
+    status: 'Active',
+    liveUrl: 'https://hexscape.kluthstudios.com',
+    launchLabel: "Play Lisa's Hexscape",
+    docsPath: '/docs/lisas-hexscape/overview',
+    technologies: ['TypeScript', 'Next.js', 'PWA', 'Web'],
+    featured: true,
+    accentColor: '#b79ce8',
+    studio: 'Kluth Studios',
+    highlights: [
+      {
+        title: 'Six directions, one rule',
+        body: 'Every hex points at one of its six neighbors and leaves only when its path is clear. The whole game is reading the board and choosing the right order.',
+      },
+      {
+        title: 'Gates, frost, switches, and stones',
+        body: 'Colored garden gates only accept matching tiles. Frosted hexes need thawing, turning hexes spin their neighbors, flower switches open and close gates, and stones never move. Each obstacle introduces itself before it counts.',
+      },
+      {
+        title: 'Thirty solver-proven levels',
+        body: "Three chapters (Twilight Trail, Moonlit Garden, Starlight Summit) climb from gentle to genuinely strategic. Every level is machine-verified solvable at par, without boosters, before it ships.",
+      },
+      {
+        title: 'A daily bloom',
+        body: 'One fresh puzzle a day, generated deterministically from the date and guaranteed solvable by construction. Same day, same puzzle, everywhere.',
+      },
+      {
+        title: 'Relaxed or challenge',
+        body: 'Relaxed levels have no move limit and allow undo. Challenge levels count every move, and four boosters (Lantern, Petal Turn, Starburst, Extra Moves) help when you are truly stuck.',
+      },
+      {
+        title: 'Cozy, accessible, installable',
+        body: 'Full keyboard play on a hex grid, color assistance badges, high contrast and reduced motion modes, and PWA installation with offline play.',
+      },
+    ],
+    gettingStarted: [
+      {
+        title: 'Open the game',
+        body: "Lisa's Hexscape runs in your browser, free, with nothing to install and no account. It plays beautifully on a phone or a desktop.",
+      },
+      {
+        title: 'Play the tutorial',
+        body: 'Three short guided boards teach arrows, blocked paths, gates, move limits, and boosters in about a minute. Replay it any time from Settings.',
+      },
+      {
+        title: 'Find your way out',
+        body: 'Clear the three chapters, chase three stars on every level, and come back each day for the Daily Bloom.',
+      },
+    ],
+    updates: [
+      {
+        date: '2026-07-19',
+        text: 'went live at hexscape.kluthstudios.com and joined the Kluth Studios collection.',
+      },
+    ],
+  },
+  {
     name: 'Skyroute',
     inGameTitle: 'SkyRoute Infinite',
     slug: 'skyroute',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,7 @@ function HeroTerminal() {
           </div>
         ))}
         <div className={styles.terminalComment}>
-          # six projects · one home · docs included
+          # seven projects · one home · docs included
         </div>
       </div>
     </div>

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -20,7 +20,7 @@ export default function ProjectsIndex(): React.ReactNode {
               as="h1"
               overline="Projects"
               title="Everything, in one place"
-              lede="Six projects, each with a live site and its own documentation. Launch anything; read how it works."
+              lede="Seven projects, each with a live site and its own documentation. Launch anything; read how it works."
             />
           </div>
         </header>

--- a/src/pages/projects/lisas-hexscape.tsx
+++ b/src/pages/projects/lisas-hexscape.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ProjectPage from '@site/src/components/ProjectPage';
+
+export default function LisasHexscapeProject(): React.ReactNode {
+  return <ProjectPage slug="lisas-hexscape" />;
+}


### PR DESCRIPTION
Adds Lisa's Hexscape, a strategic hexagonal tap-away puzzle in an enchanted twilight garden, as the seventh project on kurtkluth.dev. It is already live at [hexscape.kluthstudios.com](https://hexscape.kluthstudios.com), so the changelog carries both dated entries ("joined the collection" and "went live") from the start. Documented the same way as the other six projects.

## Portfolio
- New `src/data/projects.ts` entry (Game, Active, lilac accent), placed with the Lisa-named games
- Detail-page route at `src/pages/projects/lisas-hexscape.tsx`
- Original `ProjectArt` scene: a twilight hex cluster with directional arrow tiles, fireflies, and a hillside silhouette

## Docs
- Full six-page set under `docs/lisas-hexscape/` (overview, how-to-play, gameplay, tips, faq, changelog)
- Sidebar category block in `sidebars.ts`

## Counts and cross-links
- Bumped the hardcoded totals (six to seven projects, five to six games) on the home terminal, projects index lede, docs landing table, getting-started, and the cross-project how-to-play launcher, plus new table rows and a "jump in" section

Production `docusaurus build` passes (so no broken internal links), and the project page, art scene, docs, sidebar, and changelog were all verified rendering in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
