### PR TITLE
Add Diamond Dynasty to the portfolio and docs hub

### DIFF
--- a/docs/diamond-dynasty/changelog.md
+++ b/docs/diamond-dynasty/changelog.md
@@ -1,0 +1,18 @@
+---
+title: Changelog
+description: Release notes and status history for Diamond Dynasty on kurtkluth.dev.
+---
+
+This page records the notable moments in Diamond Dynasty's life on this
+site, newest first.
+
+## 2026-07-20: Joined the collection
+
+**Status: Active**
+
+Diamond Dynasty joined the Kluth Studios collection on kurtkluth.dev as
+its eighth project: an original baseball franchise simulator with
+stat-driven three-inning matches, procedurally generated player cards
+across six rarities, Scout Packs with published odds, coin-based
+training, pitcher fatigue with a one-call bullpen, and full PWA install
+with offline play.

--- a/docs/diamond-dynasty/faq.md
+++ b/docs/diamond-dynasty/faq.md
@@ -1,0 +1,60 @@
+---
+title: FAQ
+description: Quick answers about playing Diamond Dynasty. Cost, devices, saving, offline play, and where the players come from.
+---
+
+Quick answers to the questions players actually ask. For the longer
+version, start with the [Overview](./overview.md).
+
+## Is it free?
+
+Yes. Diamond Dynasty is free to play, with no account, no sign-up, and
+nothing to buy. Coins are earned by playing matches, spent only on packs
+and training, and never cost real money. It is the same deal as every
+Kluth Studios game.
+
+## Do I need to install anything?
+
+No. It runs entirely in your browser at
+[diamonddynasty.kluthstudios.com](https://diamonddynasty.kluthstudios.com).
+Any current Chrome, Edge, Firefox, or Safari will do. If you like,
+install it as an app from your browser's menu (or "Add to Home Screen" on
+a phone) and it will keep working offline after the first visit.
+
+## Does it work on my phone?
+
+Yes. It is built mobile-first: portrait layout, big touch targets, and a
+PWA install that launches full-screen with its own crest icon. Desktop
+with a mouse works just as well.
+
+## Where is my save?
+
+In your browser's localStorage, on the device you play on. Roster, coins,
+lineup, and settings all persist automatically between sessions. There
+are no accounts and no cloud sync, so a different browser or a private
+window starts a fresh franchise, and clearing site data erases the
+dynasty. Guard the browser that holds your roster.
+
+## Are these real players or teams?
+
+No. Every player name, club, card design, and crest is fictional,
+procedurally generated, and original to the game. The art is all
+procedural SVG and CSS, and the audio is synthesized from scratch.
+
+## Do I control every pitch?
+
+You make one decision per at-bat. Batting, you choose an approach
+(Contact, Power, or Patient). Pitching, you choose a pitch type and a
+location. The sim resolves the at-bat from those choices and the players'
+ratings. [How to Play](./how-to-play.md) covers what each option does.
+
+## Why did my pitcher fall apart?
+
+Check the PIT number and the TIRED tag; pitchers fatigue as they face
+batters. You get one bullpen call per game to fix exactly this.
+[Gameplay](./gameplay.md) explains the fatigue system.
+
+## How long is a match?
+
+Three innings, usually well under ten minutes. It is a coffee-break
+baseball game on purpose.

--- a/docs/diamond-dynasty/gameplay.md
+++ b/docs/diamond-dynasty/gameplay.md
@@ -1,0 +1,71 @@
+---
+title: Gameplay
+description: Player cards and rarities, the lineup editor, training and potential, Scout Pack odds, pitcher fatigue, and saving.
+---
+
+The match is the heartbeat, but the franchise is the game. This page
+covers the systems around the diamond.
+
+## Player cards
+
+Every player in Diamond Dynasty is procedurally generated: name, position,
+ratings, and the card art itself (each card is drawn as SVG, no two clubs
+alike). Cards come in six rarities, and rarity sets the ceiling; a higher
+rarity card arrives with better ratings and more room to grow.
+
+Batters and pitchers carry different rating sets (a slugger's power does
+not help them pitch), so building a club means collecting both sides of
+the ball.
+
+## My Team
+
+The **My Team** screen is the front office:
+
+- **Roster.** Every card you own, with ratings and rarity at a glance.
+- **Lineup editor.** Set your batting order and starting pitcher by hand,
+  or press auto-set and let the game place your best nine.
+- **Training.** Spend coins on a player to raise their ratings. Growth is
+  scaled by potential, so a young high-potential card is the better
+  long-term investment even when a veteran looks stronger today.
+
+The **team rating** number on the menu is computed from your active
+lineup. It is the score the whole loop is trying to raise.
+
+## Scout Packs
+
+Packs cost 200 coins and contain three players, revealed with an animated
+card flip. The pull odds for each rarity are published right on the packs
+screen, so you always know the deal before you buy. Duplicates still
+deepen the roster; a second good arm matters the day your starter tires
+in the second inning.
+
+## The match engine
+
+Matches are simulated stat by stat, at-bat by at-bat. Each outcome weighs:
+
+- the batter's ratings against the pitcher's,
+- your approach or pitch-and-location call,
+- the rock-paper-scissors interaction between those choices,
+- and the pitcher's current fatigue.
+
+Three innings keeps a full game under ten minutes, and every half-inning
+is played, not skipped; you make the calls for both your lineup and your
+pitching staff.
+
+## Fatigue and the bullpen
+
+A pitcher's PIT value falls with every batter faced. Low PIT flattens
+their effectiveness and raises the TIRED tag as a warning. Each club gets
+one relief call per game. The AI manager operates under the same rules
+and will go to their own bullpen when their starter fades.
+
+## Saving
+
+Everything (roster, coins, lineup, settings) persists automatically in
+your browser's localStorage. There is no account and no cloud sync, so
+the same browser on the same device is where your dynasty lives. A
+private window, a different browser, or clearing site data starts the
+franchise over.
+
+Diamond Dynasty is also a PWA: install it from the browser menu and,
+after the first visit, the whole game (audio included) works offline.

--- a/docs/diamond-dynasty/how-to-play.md
+++ b/docs/diamond-dynasty/how-to-play.md
@@ -1,0 +1,72 @@
+---
+title: How to Play
+description: Your first Quick Match, the offense and defense decisions, the bullpen, and how the coins flow.
+---
+
+Diamond Dynasty asks for one decision per at-bat and nothing more. Here is
+everything those decisions mean, plus the tour of the screens around them.
+
+## Start a match
+
+From the main menu, hit **Play Ball** for a Quick Match: three innings
+against an AI club. Your lineup comes from the My Team screen (auto-set if
+you have not touched it), and the scoreboard, count, and base runners are
+always in view.
+
+## Batting
+
+When your club is at the plate, each at-bat starts with one choice of
+approach:
+
+- **Contact.** Put the ball in play. The safe swing; fewer strikeouts,
+  fewer home runs.
+- **Power.** Swing for the fences. Big flies and big whiffs both get more
+  likely.
+- **Patient.** Work the count. Better walks and better pitches to hit
+  later in the at-bat, at the cost of taking strikes.
+
+The sim resolves the at-bat from your approach, the batter's ratings, the
+pitcher's ratings and fatigue, and the pitch the AI chose. Approaches beat
+and lose to pitch plans rock-paper-scissors style, so mix it up; a
+predictable hitter is an out.
+
+## Pitching
+
+When you are in the field, you pick two things per at-bat:
+
+- **A pitch.** Six types, each with its own movement and risk profile.
+- **A location.** **Attack** goes after the zone, **Corner** paints the
+  edge, and **Waste** throws it away hoping for a chase.
+
+Attack gets punished by locked-in hitters, Corner risks walks, Waste only
+works when the batter bites. Read the situation (count, runners, batter
+quality) and choose accordingly.
+
+## The bullpen
+
+Your pitcher's card shows a PIT number that drops as they face batters.
+When it gets low a **TIRED** tag appears and their stuff flattens out. You
+get **one** bullpen call per game; tap the bullpen button to bring in a
+fresh arm. Spend it too early and there is nothing left for the ninth...
+or in this case, the third. The AI manager watches their own starter and
+will pull them too.
+
+## After the game
+
+Win or lose, the final screen pays out coins. Winning pays better, and
+coins are the fuel for everything else:
+
+- **Scout Packs** (200 coins) deliver three new players with animated
+  flip reveals and published pull odds.
+- **Training** spends coins on a player to raise their ratings, with
+  growth scaled by their potential.
+
+## Controls
+
+Everything is tap or click; there is nothing to memorize. The game is
+mobile-first (big buttons, portrait layout) and plays equally well with a
+mouse on desktop. Sound toggles and master volume live in
+**Settings**, and your save is automatic via localStorage.
+
+Deeper systems (rarities, lineups, fatigue math, pack odds) are covered in
+[Gameplay](./gameplay.md).

--- a/docs/diamond-dynasty/overview.md
+++ b/docs/diamond-dynasty/overview.md
@@ -1,0 +1,63 @@
+---
+title: Overview
+description: What Diamond Dynasty is (an original browser baseball franchise sim) and what is inside it.
+---
+
+Diamond Dynasty is an original baseball franchise simulator that runs
+entirely in your browser. You manage a club of procedurally generated
+players, play quick stat-driven matches where every at-bat comes down to
+one decision, and pour your winnings back into the roster. Play, earn,
+recruit, train, and watch the team rating climb.
+
+The tagline is the roadmap: "Build the franchise. Create the dynasty.
+Become a legend."
+
+Play it free at
+[diamonddynasty.kluthstudios.com](https://diamonddynasty.kluthstudios.com),
+in your browser, no install, no account.
+
+## The loop
+
+Everything in Diamond Dynasty feeds one loop. A Quick Match is three
+innings of baseball, and every at-bat asks for exactly one choice. On
+offense you pick an approach: Contact, Power, or Patient. On defense you
+pick a pitch (six types) and a location (Attack, Corner, or Waste). Those
+choices interact rock-paper-scissors style on top of each player's
+ratings, so reading your opponent matters as much as raw talent.
+
+Matches pay out coins. Coins buy Scout Packs (three new players, published
+pull odds) or training sessions (growth scaled by each player's
+potential). Better players raise the team rating, and then it is back to
+the diamond.
+
+## A real manager's problems
+
+Pitchers get tired. As a starter faces batters, their PIT number drops and
+eventually a TIRED tag appears, and a tired pitcher is a hittable pitcher.
+Each side gets exactly one call to the bullpen per game, so the decision
+of when to burn it is yours. The AI manager in the opposing dugout watches
+their own starter and makes the same call.
+
+## Original by design
+
+Every visual in the game (player cards, the crest, the stadium, the pack
+art) is procedural SVG and CSS, and every sound (the bat crack, the crowd,
+the organ loop, the UI clicks) is synthesized from scratch. All player
+names, clubs, and card designs are fictional and original.
+
+## Made for your pocket
+
+Diamond Dynasty is mobile-first and installs as a PWA. Add it to your home
+screen and it launches full-screen with its own crest icon, and after the
+first visit it plays entirely offline. Your save lives in the browser via
+localStorage; there is no server, no account, and nothing to sign up for.
+
+## Where to go next
+
+- [How to Play](./how-to-play.md) walks the controls and your first match.
+- [Gameplay](./gameplay.md) covers rarities, training, packs, and fatigue
+  in depth.
+- [Tips](./tips.md) is the shortcut to winning more at-bats.
+- [FAQ](./faq.md) answers the quick questions.
+- The portfolio page is at
+  [/projects/diamond-dynasty](/projects/diamond-dynasty).

--- a/docs/diamond-dynasty/tips.md
+++ b/docs/diamond-dynasty/tips.md
@@ -1,0 +1,52 @@
+---
+title: Tips
+description: Practical advice for winning at-bats, managing the bullpen, and spending coins like a general manager.
+---
+
+Seven habits that turn close losses into wins. None of them require luck,
+just doing them on purpose.
+
+## Mix your approaches like a real hitter
+
+If you pick Power every at-bat, you are the easiest out in the league.
+The sim rewards unpredictability; rotate Contact, Power, and Patient so
+the matchup math does not settle against you. Save Power for tired
+pitchers and hitter's counts.
+
+## Pitch backward when the batter is dangerous
+
+Against a strong batter, do not challenge with Attack just because it
+feels proactive. Paint with Corner or make them chase with Waste, and
+save Attack for weak hitters and pitcher's counts. Walking a slugger
+costs one base; grooving one costs the game.
+
+## Respect the TIRED tag
+
+A tired pitcher is not slightly worse, they are a batting-practice
+machine. When the PIT number gets low, plan the bullpen call before the
+damage, not after. And remember you only get one; if it is the second
+inning and your starter is gassed, weigh the innings left.
+
+## Bait the AI's tired starter
+
+Fatigue cuts both ways. When the opposing starter is deep in the TIRED
+zone and the AI has not pulled them yet, that is the moment to swing
+Power. The window closes the instant their bullpen door opens.
+
+## Train potential, not nostalgia
+
+Training coins grow a player toward their potential, so a high-potential
+young card out-earns a maxed veteran over time. Check potential before
+you spend; the best investment is rarely the current best player.
+
+## Auto-set, then second-guess it
+
+The lineup auto-set places your best nine instantly and is right most of
+the time. Glance over it anyway after every pack; a new arrival can slot
+in the moment the flip animation ends.
+
+## Coins love a plan
+
+200 coins is a pack, but it is also several training sessions. Early on,
+packs grow the roster fastest; once your lineup is set, targeted training
+on high-potential starters usually beats another spin of the odds.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ deployment, and troubleshooting in depth.
 
 ### You're here to play
 
-Kluth Studios ships six browser games and interactive experiences. All of
+Kluth Studios ships seven browser games and interactive experiences. All of
 them run instantly in the browser. No install, no account, and free. Pick
 one and go:
 
@@ -38,6 +38,8 @@ one and go:
   puzzle game, made for Lisa.
 - [Lisa's Hexscape](./lisas-hexscape/overview.md) is a strategic hexagon
   puzzle in a twilight garden, made for Lisa.
+- [Diamond Dynasty](./diamond-dynasty/overview.md) is an original baseball
+  franchise sim. Build the roster, call the pitches, become a legend.
 - [Skyroute](./skyroute/overview.md) is SkyRoute Infinite, an open-world
   browser flight simulator.
 - [Spindrift](./spindrift/overview.md) is a vector-style arcade space

--- a/docs/guides/how-to-play.md
+++ b/docs/guides/how-to-play.md
@@ -1,6 +1,6 @@
 ---
 title: How to Play
-description: What every Kluth Studios game has in common, a quick launcher for all six, and where to learn each one in depth.
+description: What every Kluth Studios game has in common, a quick launcher for all seven, and where to learn each one in depth.
 ---
 
 Every Kluth Studios game follows the same philosophy. Click the link, play
@@ -13,9 +13,9 @@ game's own how-to-play page for the specifics.
   account, no payment, ever.
 - **Keyboard-first, with touch where it fits.** Every game plays great on a
   keyboard. Lisa Climber, Lisetris, and Spindrift also support touch, and
-  Lisa's Tapistry and Lisa's Hexscape are built for touch first, so phones
-  and tablets work well. Skyroute has enough controls that it strongly
-  prefers a keyboard.
+  Lisa's Tapistry, Lisa's Hexscape, and Diamond Dynasty are built for touch
+  first, so phones and tablets work well. Skyroute has enough controls that
+  it strongly prefers a keyboard.
 - **Scores and progress live in your browser.** High scores, stats, and
   settings are stored locally on the device you play on; nothing is sent
   to a server.
@@ -40,6 +40,7 @@ cloud sync. Guard the browser that holds your high scores.
 | Lisetris | A romantic neon falling-block puzzle game, made for Lisa | [lisetris.kluthstudios.com](https://lisetris.kluthstudios.com) | [Overview](../lisetris/overview.md) |
 | Lisa's Tapistry | A cozy tap-away mosaic puzzle, made for Lisa | [tapistry.kluthstudios.com](https://tapistry.kluthstudios.com) | [Overview](../lisas-tapistry/overview.md) |
 | Lisa's Hexscape | A strategic hexagon puzzle in a twilight garden, made for Lisa | [hexscape.kluthstudios.com](https://hexscape.kluthstudios.com) | [Overview](../lisas-hexscape/overview.md) |
+| Diamond Dynasty | An original baseball franchise sim in the browser | [diamonddynasty.kluthstudios.com](https://diamonddynasty.kluthstudios.com) | [Overview](../diamond-dynasty/overview.md) |
 | Skyroute | SkyRoute Infinite, an open-world browser flight simulator | [skyroute.kluthstudios.com](https://skyroute.kluthstudios.com) | [Overview](../skyroute/overview.md) |
 | Spindrift | A vector-style arcade space shooter in the Asteroids tradition | [spindrift.kluthstudios.com](https://spindrift.kluthstudios.com) | [Overview](../spindrift/overview.md) |
 
@@ -82,6 +83,16 @@ matching tiles, plus frost, switches, and turning hexes. Thirty levels,
 a deterministic daily puzzle, and full keyboard play (arrow keys walk the
 grid, `Enter` clears). It teaches itself in a one-minute tutorial. Full
 details: [Lisa's Hexscape How to Play](../lisas-hexscape/how-to-play.md).
+
+### Diamond Dynasty
+
+A baseball franchise sim, one decision per at-bat. Batting, choose Contact,
+Power, or Patient; pitching, choose one of six pitches and a location
+(Attack, Corner, or Waste). Choices interact rock-paper-scissors style on
+top of player ratings, pitchers tire as they work, and each side gets one
+bullpen call per game. Between matches, open Scout Packs, train players,
+and raise the team rating. Everything is a tap or a click. Full details:
+[Diamond Dynasty How to Play](../diamond-dynasty/how-to-play.md).
 
 ### Skyroute
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ promise lives.
 
 ## The projects
 
-Seven projects, one hub. Each name links to that project's overview doc, and
+Eight projects, one hub. Each name links to that project's overview doc, and
 each live link opens the real thing.
 
 | Project | One-liner | Live site |
@@ -22,10 +22,11 @@ each live link opens the real thing.
 | [Lisetris](./lisetris/overview.md) | A romantic neon falling-block puzzle game, made for Lisa. | [lisetris.kluthstudios.com](https://lisetris.kluthstudios.com) |
 | [Lisa's Tapistry](./lisas-tapistry/overview.md) | A cozy tap-away mosaic puzzle. Clear the tiles, reveal the picture. | [tapistry.kluthstudios.com](https://tapistry.kluthstudios.com) |
 | [Lisa's Hexscape](./lisas-hexscape/overview.md) | A strategic hexagon puzzle in a twilight garden. Follow the arrows, find your way out. | [hexscape.kluthstudios.com](https://hexscape.kluthstudios.com) |
+| [Diamond Dynasty](./diamond-dynasty/overview.md) | An original baseball franchise sim. Build the roster, call the pitches, become a legend. | [diamonddynasty.kluthstudios.com](https://diamonddynasty.kluthstudios.com) |
 | [Skyroute](./skyroute/overview.md) | SkyRoute Infinite, an open-world flight simulator that runs straight from your browser. | [skyroute.kluthstudios.com](https://skyroute.kluthstudios.com) |
 | [Spindrift](./spindrift/overview.md) | A vector-style arcade space shooter with a persistent high score to chase. | [spindrift.kluthstudios.com](https://spindrift.kluthstudios.com) |
 
-SQLCLR is the serious developer tool. The other six are Kluth Studios games
+SQLCLR is the serious developer tool. The other seven are Kluth Studios games
 and interactive experiences. All of them are free, all in the browser, with
 no install and no account required.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -83,6 +83,19 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Diamond Dynasty',
+      link: {type: 'doc', id: 'diamond-dynasty/overview'},
+      items: [
+        'diamond-dynasty/overview',
+        'diamond-dynasty/how-to-play',
+        'diamond-dynasty/gameplay',
+        'diamond-dynasty/tips',
+        'diamond-dynasty/faq',
+        'diamond-dynasty/changelog',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Skyroute',
       link: {type: 'doc', id: 'skyroute/overview'},
       items: [

--- a/src/components/ProjectArt/index.tsx
+++ b/src/components/ProjectArt/index.tsx
@@ -325,6 +325,68 @@ function LisasHexscapeArt() {
   );
 }
 
+function DiamondDynastyArt() {
+  return (
+    <svg viewBox="0 0 400 225" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <defs>
+        <linearGradient id="dd-sky" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#101f3d" />
+          <stop offset="1" stopColor="#050b18" />
+        </linearGradient>
+        <linearGradient id="dd-gold" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#f8e7b3" />
+          <stop offset="0.55" stopColor="#e8c25a" />
+          <stop offset="1" stopColor="#b08a2e" />
+        </linearGradient>
+        <radialGradient id="dd-lights" cx="0.5" cy="0.25" r="0.75">
+          <stop offset="0" stopColor="#22396a" stopOpacity="0.9" />
+          <stop offset="1" stopColor="#050b18" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="400" height="225" fill="url(#dd-sky)" />
+      <rect width="400" height="225" fill="url(#dd-lights)" />
+      {/* floodlight towers */}
+      <g stroke="#39537a" strokeWidth="2.5" fill="none">
+        <path d="M52 118V52M40 52h24M40 44h24" />
+        <path d="M348 118V52M336 52h24M336 44h24" />
+      </g>
+      <g fill="#f4e9c8">
+        <circle cx="44" cy="48" r="2.6" />
+        <circle cx="52" cy="48" r="2.6" />
+        <circle cx="60" cy="48" r="2.6" />
+        <circle cx="340" cy="48" r="2.6" />
+        <circle cx="348" cy="48" r="2.6" />
+        <circle cx="356" cy="48" r="2.6" />
+      </g>
+      {/* outfield wall + infield diamond */}
+      <path d="M30 168q170-64 340 0" fill="none" stroke="#22396a" strokeWidth="3" />
+      <g fill="none" stroke="url(#dd-gold)" strokeWidth="2.5">
+        <path d="M200 196 L268 152 L200 108 L132 152 Z" />
+        <path d="M200 196 Q166 176 163 152 Q166 128 200 108 Q234 128 237 152 Q234 176 200 196" opacity="0.35" />
+      </g>
+      <g fill="#e8c25a">
+        <rect x="196" y="192" width="8" height="8" transform="rotate(45 200 196)" />
+        <rect x="264" y="148" width="8" height="8" transform="rotate(45 268 152)" />
+        <rect x="196" y="104" width="8" height="8" transform="rotate(45 200 108)" />
+        <rect x="128" y="148" width="8" height="8" transform="rotate(45 132 152)" />
+      </g>
+      {/* crest shield above the diamond */}
+      <g transform="translate(178 28) scale(0.37)">
+        <path
+          d="M60 4 L110 22 L110 62 Q110 96 60 116 Q10 96 10 62 L10 22 Z"
+          fill="#0a1428"
+          stroke="url(#dd-gold)"
+          strokeWidth="5"
+        />
+        <path d="M60 48 L63.2 56.2 L72 56.6 L65.2 62.2 L67.4 70.6 L60 65.8 L52.6 70.6 L54.8 62.2 L48 56.6 L56.8 56.2 Z" fill="url(#dd-gold)" />
+      </g>
+      <text x="200" y="216" textAnchor="middle" fontFamily="JetBrains Mono Variable, monospace" fontSize="10" letterSpacing="4" fill="rgba(232,194,90,0.75)">
+        BUILD THE FRANCHISE
+      </text>
+    </svg>
+  );
+}
+
 function SkyrouteArt() {
   return (
     <svg viewBox="0 0 400 225" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -429,6 +491,7 @@ const ART: Record<string, () => React.ReactNode> = {
   lisetris: LisetrisArt,
   'lisas-tapistry': LisasTapistryArt,
   'lisas-hexscape': LisasHexscapeArt,
+  'diamond-dynasty': DiamondDynastyArt,
   skyroute: SkyrouteArt,
   spindrift: SpindriftArt,
 };

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -348,6 +348,70 @@ export const PROJECTS: Project[] = [
     ],
   },
   {
+    name: 'Diamond Dynasty',
+    inGameTitle: 'Diamond Dynasty: Legends Rising',
+    slug: 'diamond-dynasty',
+    summary:
+      'A baseball franchise sim in the browser. Build the roster, call the pitches, become a legend.',
+    lede:
+      'An original baseball franchise simulator. Play stat-driven three-inning matches where every at-bat is one decision (an approach at the plate, a pitch and location on the mound), earn coins, open scout packs, train your players, and raise your team rating. Build the franchise. Create the dynasty. Become a legend.',
+    category: 'Game',
+    status: 'Active',
+    liveUrl: 'https://diamonddynasty.kluthstudios.com',
+    launchLabel: 'Play Diamond Dynasty',
+    docsPath: '/docs/diamond-dynasty/overview',
+    technologies: ['TypeScript', 'Next.js', 'PWA', 'Web'],
+    featured: true,
+    accentColor: '#e8c25a',
+    studio: 'Kluth Studios',
+    highlights: [
+      {
+        title: 'One decision per at-bat',
+        body: 'On offense pick an approach (Contact, Power, or Patient); on defense pick one of six pitch types and a location (Attack, Corner, or Waste). Approaches and pitches interact rock-paper-scissors style on top of real player ratings, so every choice matters and none of them takes longer than a breath.',
+      },
+      {
+        title: 'A bullpen with consequences',
+        body: 'Pitchers tire as they face batters; watch the PIT number drop and the TIRED tag appear. Each side gets exactly one call to the bullpen per game, and the AI manager knows when to pull a fading starter too.',
+      },
+      {
+        title: 'Cards, packs, and training',
+        body: 'A roster of procedurally generated player cards across six rarities. Scout Packs cost 200 coins for three players with published pull odds, and coin-based training grows players toward their potential.',
+      },
+      {
+        title: 'The franchise loop',
+        body: 'Play a Quick Match, earn coins, open packs or train players, and watch the team rating climb. Then do it again, because the dynasty does not build itself.',
+      },
+      {
+        title: 'Original by design',
+        body: 'Every card, crest, stadium, and pack is procedural SVG and CSS; every sound (bat crack, crowd, organ loop) is synthesized from scratch. All names, clubs, and designs are fictional and original.',
+      },
+      {
+        title: 'Installable and offline',
+        body: 'A full PWA. Add it to your home screen and, after the first visit, it plays entirely offline. Saves live in your browser; no account, no server, no sign-up.',
+      },
+    ],
+    gettingStarted: [
+      {
+        title: 'Open the game',
+        body: 'Diamond Dynasty runs in your browser, free, with nothing to install and no account. It is mobile-first and desktop-ready.',
+      },
+      {
+        title: 'Play a Quick Match',
+        body: 'Three innings, one decision per at-bat. Win or lose, you earn coins for the franchise.',
+      },
+      {
+        title: 'Build the dynasty',
+        body: 'Spend coins on Scout Packs and training, set your lineup, and raise the team rating. The how-to-play doc covers every screen.',
+      },
+    ],
+    updates: [
+      {
+        date: '2026-07-20',
+        text: 'joined the Kluth Studios collection on kurtkluth.dev.',
+      },
+    ],
+  },
+  {
     name: 'Skyroute',
     inGameTitle: 'SkyRoute Infinite',
     slug: 'skyroute',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,7 @@ function HeroTerminal() {
           </div>
         ))}
         <div className={styles.terminalComment}>
-          # seven projects · one home · docs included
+          # eight projects · one home · docs included
         </div>
       </div>
     </div>

--- a/src/pages/projects/diamond-dynasty.tsx
+++ b/src/pages/projects/diamond-dynasty.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ProjectPage from '@site/src/components/ProjectPage';
+
+export default function DiamondDynastyProject(): React.ReactNode {
+  return <ProjectPage slug="diamond-dynasty" />;
+}

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -20,7 +20,7 @@ export default function ProjectsIndex(): React.ReactNode {
               as="h1"
               overline="Projects"
               title="Everything, in one place"
-              lede="Seven projects, each with a live site and its own documentation. Launch anything; read how it works."
+              lede="Eight projects, each with a live site and its own documentation. Launch anything; read how it works."
             />
           </div>
         </header>


### PR DESCRIPTION
Adds **Diamond Dynasty: Legends Rising** (an original baseball franchise simulator, diamonddynasty.kluthstudios.com) as the eighth project, per NEW-GAME-PLAYBOOK.md:

- `src/data/projects.ts` entry (gold accent `#e8c25a`, featured, Game/Active)
- `src/pages/projects/diamond-dynasty.tsx` detail route
- `ProjectArt` stadium-night SVG scene (floodlights, gold infield diamond, crest)
- `docs/diamond-dynasty/` six-page set (overview, how-to-play, gameplay, tips, faq, changelog)
- `sidebars.ts` category block (after Lisa's Hexscape, matching projects.ts order)
- Count bumps: home terminal comment, projects index lede, docs landing (+ table row), getting started (+ list item), how-to-play guide (+ launch row and jump-in section)

`npm run build` is green (broken-link gate) and the project page, docs, and grid were verified against the built output locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)