### PR TITLE
Record Diamond Dynasty going live

### DIFF
--- a/docs/diamond-dynasty/changelog.md
+++ b/docs/diamond-dynasty/changelog.md
@@ -4,7 +4,17 @@ description: Release notes and status history for Diamond Dynasty on kurtkluth.d
 ---
 
 This page records the notable moments in Diamond Dynasty's life on this
-site, newest first.
+site, newest first. It arrived all at once, so today there are two.
+
+## 2026-07-20: Went live
+
+**Status: Active**
+
+Diamond Dynasty went live at
+[diamonddynasty.kluthstudios.com](https://diamonddynasty.kluthstudios.com).
+The game is now playable in the browser, mobile-first and installable as
+an app, and the Play and live-site links across kurtkluth.dev resolve to
+the real thing.
 
 ## 2026-07-20: Joined the collection
 

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -407,7 +407,7 @@ export const PROJECTS: Project[] = [
     updates: [
       {
         date: '2026-07-20',
-        text: 'joined the Kluth Studios collection on kurtkluth.dev.',
+        text: 'went live at diamonddynasty.kluthstudios.com and joined the Kluth Studios collection.',
       },
     ],
   },


### PR DESCRIPTION
Post-launch step from NEW-GAME-PLAYBOOK.md: Diamond Dynasty is live at diamonddynasty.kluthstudios.com (manifest, og image, and service worker all verified serving on the custom domain), so the changelog gets its dated "Went live" entry and the projects.ts update line now carries the live URL, matching the Lisa's Hexscape precedent.

Docusaurus build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)