### PR TITLE
Document Diamond Dynasty in-game tutorial and master mute

### DIFF
--- a/docs/diamond-dynasty/changelog.md
+++ b/docs/diamond-dynasty/changelog.md
@@ -4,7 +4,18 @@ description: Release notes and status history for Diamond Dynasty on kurtkluth.d
 ---
 
 This page records the notable moments in Diamond Dynasty's life on this
-site, newest first. It arrived all at once, so today there are two.
+site, newest first.
+
+## 2026-07-20: In-game tutorial and one-tap mute
+
+**Status: Active**
+
+The game now teaches itself. An interactive How to Play primer opens
+before your first match, with hands-on batting and pitching demos where
+you make the call and the game explains why it worked (or did not). It
+stays available from the main menu and the pregame screen. A master mute
+button also landed on every screen, including mid-match; one tap
+silences everything and the choice persists.
 
 ## 2026-07-20: Went live
 

--- a/docs/diamond-dynasty/faq.md
+++ b/docs/diamond-dynasty/faq.md
@@ -48,6 +48,21 @@ You make one decision per at-bat. Batting, you choose an approach
 location. The sim resolves the at-bat from those choices and the players'
 ratings. [How to Play](./how-to-play.md) covers what each option does.
 
+## How do I learn the game?
+
+It teaches you. An interactive How to Play primer opens automatically
+before your first match, with hands-on batting and pitching demos that
+explain every outcome. Reopen it any time from the main menu or the
+pregame screen, or read [How to Play](./how-to-play.md) here.
+
+## How do I turn the sound off?
+
+Tap the speaker button; it is on every screen (the menu, your team,
+packs, settings, and right in the middle of a live match). One tap
+silences everything, another brings it back, and the choice sticks
+between sessions. Finer controls (separate music and effects toggles,
+master volume) live in Settings.
+
 ## Why did my pitcher fall apart?
 
 Check the PIT number and the TIRED tag; pitchers fatigue as they face

--- a/docs/diamond-dynasty/how-to-play.md
+++ b/docs/diamond-dynasty/how-to-play.md
@@ -3,8 +3,11 @@ title: How to Play
 description: Your first Quick Match, the offense and defense decisions, the bullpen, and how the coins flow.
 ---
 
-Diamond Dynasty asks for one decision per at-bat and nothing more. Here is
-everything those decisions mean, plus the tour of the screens around them.
+Diamond Dynasty teaches itself: an interactive How to Play primer opens
+before your first match, with hands-on batting and pitching demos where
+you make the call and the game explains the outcome. You can reopen it
+any time from the main menu or the pregame screen. Here is the same
+lesson in writing.
 
 ## Start a match
 

--- a/docs/diamond-dynasty/overview.md
+++ b/docs/diamond-dynasty/overview.md
@@ -54,6 +54,10 @@ localStorage; there is no server, no account, and nothing to sign up for.
 
 ## Where to go next
 
+The game itself opens with an interactive How to Play primer (including
+try-it batting and pitching demos) before your first match, and these
+docs go deeper:
+
 - [How to Play](./how-to-play.md) walks the controls and your first match.
 - [Gameplay](./gameplay.md) covers rarities, training, packs, and fatigue
   in depth.

--- a/docs/guides/how-to-play.md
+++ b/docs/guides/how-to-play.md
@@ -91,7 +91,9 @@ Power, or Patient; pitching, choose one of six pitches and a location
 (Attack, Corner, or Waste). Choices interact rock-paper-scissors style on
 top of player ratings, pitchers tire as they work, and each side gets one
 bullpen call per game. Between matches, open Scout Packs, train players,
-and raise the team rating. Everything is a tap or a click. Full details:
+and raise the team rating. Everything is a tap or a click, and an
+interactive tutorial with hands-on demos teaches it all before your
+first match. Full details:
 [Diamond Dynasty How to Play](../diamond-dynasty/how-to-play.md).
 
 ### Skyroute

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -396,8 +396,8 @@ export const PROJECTS: Project[] = [
         body: 'Diamond Dynasty runs in your browser, free, with nothing to install and no account. It is mobile-first and desktop-ready.',
       },
       {
-        title: 'Play a Quick Match',
-        body: 'Three innings, one decision per at-bat. Win or lose, you earn coins for the franchise.',
+        title: 'Play the tutorial',
+        body: 'An interactive How to Play primer opens before your first match, with hands-on batting and pitching demos. Then it is three innings, one decision per at-bat, and coins either way.',
       },
       {
         title: 'Build the dynasty',
@@ -405,6 +405,10 @@ export const PROJECTS: Project[] = [
       },
     ],
     updates: [
+      {
+        date: '2026-07-20',
+        text: 'gained an in-game interactive tutorial and a one-tap master mute on every screen.',
+      },
       {
         date: '2026-07-20',
         text: 'went live at diamonddynasty.kluthstudios.com and joined the Kluth Studios collection.',


### PR DESCRIPTION
The game shipped an interactive How to Play primer (auto-opens before the first match, hands-on batting and pitching demos, reopenable from the menu and pregame) and a persistent one-tap master mute on every screen. This PR updates the docs to match, following the Hexscape "teaches itself" precedent:

- `docs/diamond-dynasty/how-to-play.md` opener now points at the in-game primer
- `docs/diamond-dynasty/overview.md` mentions it in Where to go next
- `docs/diamond-dynasty/faq.md` gains "How do I learn the game?" and "How do I turn the sound off?"
- `docs/diamond-dynasty/changelog.md` gets a dated entry
- `src/data/projects.ts` getting-started step becomes "Play the tutorial" plus an updates-feed entry
- `docs/guides/how-to-play.md` jump-in section mentions the tutorial

Docusaurus build is green; no em/en dashes introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)