### PR TITLE
Update Diamond Dynasty docs for the action gameplay

### DIFF
--- a/docs/diamond-dynasty/changelog.md
+++ b/docs/diamond-dynasty/changelog.md
@@ -6,6 +6,19 @@ description: Release notes and status history for Diamond Dynasty on kurtkluth.d
 This page records the notable moments in Diamond Dynasty's life on this
 site, newest first.
 
+## 2026-07-20: Timing-based batting, live pitches, and music tracks
+
+**Status: Active**
+
+The match became an action game. Batting is now a timing challenge: the
+pitch flies in and you swing as a gold ring lands on the ball, so your
+reflexes matter as much as your roster, and chasing pitches outside the
+zone gets punished. The pitching half animates too, with your called
+pitch flying to its location and the batter reacting. The How to Play
+tutorial gained a live batting practice cage, and Settings gained a
+choice of three music beds (Ballpark Organ, Night Game, and Walk-Up Jam)
+plus a rally horn and crowd groan on the big moments.
+
 ## 2026-07-20: In-game tutorial and one-tap mute
 
 **Status: Active**

--- a/docs/diamond-dynasty/faq.md
+++ b/docs/diamond-dynasty/faq.md
@@ -41,12 +41,13 @@ No. Every player name, club, card design, and crest is fictional,
 procedurally generated, and original to the game. The art is all
 procedural SVG and CSS, and the audio is synthesized from scratch.
 
-## Do I control every pitch?
+## Do I play every pitch?
 
-You make one decision per at-bat. Batting, you choose an approach
-(Contact, Power, or Patient). Pitching, you choose a pitch type and a
-location. The sim resolves the at-bat from those choices and the players'
-ratings. [How to Play](./how-to-play.md) covers what each option does.
+Yes. Batting, you time each swing as the pitch reaches the plate (tap or
+press Space when the gold ring lands on the ball). Pitching, you call a
+pitch type and a location and watch it fly in. Your timing and calls
+combine with the players' ratings to decide each outcome.
+[How to Play](./how-to-play.md) covers both sides.
 
 ## How do I learn the game?
 
@@ -60,8 +61,10 @@ pregame screen, or read [How to Play](./how-to-play.md) here.
 Tap the speaker button; it is on every screen (the menu, your team,
 packs, settings, and right in the middle of a live match). One tap
 silences everything, another brings it back, and the choice sticks
-between sessions. Finer controls (separate music and effects toggles,
-master volume) live in Settings.
+between sessions. Finer controls live in Settings: separate music and
+effects toggles, master volume, and a choice of three music beds
+(Ballpark Organ, Night Game, or Walk-Up Jam) that preview as you pick
+them.
 
 ## Why did my pitcher fall apart?
 

--- a/docs/diamond-dynasty/gameplay.md
+++ b/docs/diamond-dynasty/gameplay.md
@@ -41,16 +41,18 @@ in the second inning.
 
 ## The match engine
 
-Matches are simulated stat by stat, at-bat by at-bat. Each outcome weighs:
+Matches play out pitch by pitch. When you bat, a swing outcome weighs:
 
-- the batter's ratings against the pitcher's,
-- your approach or pitch-and-location call,
-- the rock-paper-scissors interaction between those choices,
+- how close your swing timing was to the ball crossing the plate,
+- whether you swung at a strike or chased a ball outside the zone,
+- the batter's rating against the pitcher's,
 - and the pitcher's current fatigue.
 
-Three innings keeps a full game under ten minutes, and every half-inning
-is played, not skipped; you make the calls for both your lineup and your
-pitching staff.
+When you pitch, the outcome weighs your pitch and location call against
+the batter's rating and your pitcher's rating and fatigue. Both halves
+animate on the field: your swings against a live pitch, your calls flying
+to the plate. Three innings keeps a full game under ten minutes, and every
+half-inning is played, not skipped.
 
 ## Fatigue and the bullpen
 

--- a/docs/diamond-dynasty/how-to-play.md
+++ b/docs/diamond-dynasty/how-to-play.md
@@ -18,32 +18,37 @@ always in view.
 
 ## Batting
 
-When your club is at the plate, each at-bat starts with one choice of
-approach:
+Batting is a timing game. The pitch flies in from the mound and a gold
+ring closes on the ball as it reaches the plate. Swing (tap the field or
+press **Space**) the instant the ring lands on the ball:
 
-- **Contact.** Put the ball in play. The safe swing; fewer strikeouts,
-  fewer home runs.
-- **Power.** Swing for the fences. Big flies and big whiffs both get more
-  likely.
-- **Patient.** Work the count. Better walks and better pitches to hit
-  later in the at-bat, at the cost of taking strikes.
+- **Nail the timing** and good contact turns into extra bases; a perfect
+  swing on a hittable pitch is how home runs happen.
+- **Mistime it** and you foul it off, miss for a strike, or roll out
+  weakly.
+- **Watch the strike zone.** Chasing a pitch outside the white box weakens
+  contact badly. Lay off and it is a ball; four balls is a walk.
 
-The sim resolves the at-bat from your approach, the batter's ratings, the
-pitcher's ratings and fatigue, and the pitch the AI chose. Approaches beat
-and lose to pitch plans rock-paper-scissors style, so mix it up; a
-predictable hitter is an out.
+Your batter's BAT rating raises the ceiling on every swing, and the
+pitcher's rating (minus any fatigue) drags it down, so a stronger hitter
+against a tired arm is your best chance to do damage. Read the pitch name
+during the windup: fastballs arrive hot, curves hang, knuckleballs
+flutter.
 
 ## Pitching
 
-When you are in the field, you pick two things per at-bat:
+When you are in the field, you pick two things per at-bat, then watch the
+pitch fly to the plate and the batter react:
 
-- **A pitch.** Six types, each with its own movement and risk profile.
-- **A location.** **Attack** goes after the zone, **Corner** paints the
-  edge, and **Waste** throws it away hoping for a chase.
+- **A pitch.** Six types, each with its own movement (and the knuckleball
+  dances).
+- **A location.** **Attack** goes right after the zone, **Corner** paints
+  the edge, and **Waste** throws it off the plate hoping for a chase.
 
 Attack gets punished by locked-in hitters, Corner risks walks, Waste only
 works when the batter bites. Read the situation (count, runners, batter
-quality) and choose accordingly.
+quality) and choose accordingly. Your pitcher's rating and fatigue, the
+batter's rating, and your location all decide the outcome.
 
 ## The bullpen
 
@@ -66,10 +71,11 @@ coins are the fuel for everything else:
 
 ## Controls
 
-Everything is tap or click; there is nothing to memorize. The game is
-mobile-first (big buttons, portrait layout) and plays equally well with a
-mouse on desktop. Sound toggles and master volume live in
-**Settings**, and your save is automatic via localStorage.
+Tap or click for everything, including the swing; the one keyboard shortcut
+is **Space** to swing while batting. The game is mobile-first (big buttons,
+portrait layout) and plays equally well with a mouse on desktop. Sound
+toggles, master volume, and your choice of music bed live in **Settings**,
+and your save is automatic via localStorage.
 
 Deeper systems (rarities, lineups, fatigue math, pack odds) are covered in
 [Gameplay](./gameplay.md).

--- a/docs/diamond-dynasty/overview.md
+++ b/docs/diamond-dynasty/overview.md
@@ -5,9 +5,10 @@ description: What Diamond Dynasty is (an original browser baseball franchise sim
 
 Diamond Dynasty is an original baseball franchise simulator that runs
 entirely in your browser. You manage a club of procedurally generated
-players, play quick stat-driven matches where every at-bat comes down to
-one decision, and pour your winnings back into the roster. Play, earn,
-recruit, train, and watch the team rating climb.
+players, play quick action matches where you time your swings at the
+plate and call your pitches on the mound, and pour your winnings back
+into the roster. Play, earn, recruit, train, and watch the team rating
+climb.
 
 The tagline is the roadmap: "Build the franchise. Create the dynasty.
 Become a legend."
@@ -19,11 +20,11 @@ in your browser, no install, no account.
 ## The loop
 
 Everything in Diamond Dynasty feeds one loop. A Quick Match is three
-innings of baseball, and every at-bat asks for exactly one choice. On
-offense you pick an approach: Contact, Power, or Patient. On defense you
-pick a pitch (six types) and a location (Attack, Corner, or Waste). Those
-choices interact rock-paper-scissors style on top of each player's
-ratings, so reading your opponent matters as much as raw talent.
+innings of baseball played pitch by pitch. On offense you swing by timing
+a gold ring as the ball reaches the plate; on defense you call a pitch
+(six types) and a location (Attack, Corner, or Waste) and watch it fly.
+Your timing and your calls sit on top of each player's ratings, so a
+sharp eye and a strong roster both matter.
 
 Matches pay out coins. Coins buy Scout Packs (three new players, published
 pull odds) or training sessions (growth scaled by each player's

--- a/docs/diamond-dynasty/tips.md
+++ b/docs/diamond-dynasty/tips.md
@@ -3,15 +3,22 @@ title: Tips
 description: Practical advice for winning at-bats, managing the bullpen, and spending coins like a general manager.
 ---
 
-Seven habits that turn close losses into wins. None of them require luck,
+Eight habits that turn close losses into wins. None of them require luck,
 just doing them on purpose.
 
-## Mix your approaches like a real hitter
+## Wait for the ball, do not lunge at it
 
-If you pick Power every at-bat, you are the easiest out in the league.
-The sim rewards unpredictability; rotate Contact, Power, and Patient so
-the matchup math does not settle against you. Save Power for tired
-pitchers and hitter's counts.
+The single biggest jump in hitting is patience with your swing. Let the
+ball travel and swing as the gold ring lands on it, not when you first
+see it leave the hand. Early swings foul off or roll over; a swing timed
+to the arrival is what drives the ball.
+
+## Lay off the chase
+
+A pitch outside the white zone is a trap: your contact is cut down hard if
+you swing, and doing nothing turns it into a ball. Take the free ones,
+work the count, and make the pitcher come to you. Four balls is a base
+without a single swing.
 
 ## Pitch backward when the batter is dangerous
 
@@ -29,9 +36,11 @@ inning and your starter is gassed, weigh the innings left.
 
 ## Bait the AI's tired starter
 
-Fatigue cuts both ways. When the opposing starter is deep in the TIRED
-zone and the AI has not pulled them yet, that is the moment to swing
-Power. The window closes the instant their bullpen door opens.
+Fatigue cuts both ways. A tired pitcher literally throws slower, and slow
+pitches are far easier to time. When the opposing starter is deep in the
+TIRED zone and the AI has not pulled them yet, that is the moment to
+attack every hittable pitch. The window closes the instant their bullpen
+door opens.
 
 ## Train potential, not nostalgia
 

--- a/docs/guides/how-to-play.md
+++ b/docs/guides/how-to-play.md
@@ -86,14 +86,13 @@ details: [Lisa's Hexscape How to Play](../lisas-hexscape/how-to-play.md).
 
 ### Diamond Dynasty
 
-A baseball franchise sim, one decision per at-bat. Batting, choose Contact,
-Power, or Patient; pitching, choose one of six pitches and a location
-(Attack, Corner, or Waste). Choices interact rock-paper-scissors style on
-top of player ratings, pitchers tire as they work, and each side gets one
-bullpen call per game. Between matches, open Scout Packs, train players,
-and raise the team rating. Everything is a tap or a click, and an
-interactive tutorial with hands-on demos teaches it all before your
-first match. Full details:
+A baseball franchise sim you play pitch by pitch. Batting, time your swing
+as the gold ring lands on the ball (tap or press Space); pitching, call
+one of six pitches and a location (Attack, Corner, or Waste) and watch it
+fly. Player ratings and pitcher fatigue shade every result, and each side
+gets one bullpen call per game. Between matches, open Scout Packs, train
+players, and raise the team rating. An interactive tutorial with a live
+practice cage teaches it all before your first match. Full details:
 [Diamond Dynasty How to Play](../diamond-dynasty/how-to-play.md).
 
 ### Skyroute

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -354,7 +354,7 @@ export const PROJECTS: Project[] = [
     summary:
       'A baseball franchise sim in the browser. Build the roster, call the pitches, become a legend.',
     lede:
-      'An original baseball franchise simulator. Play stat-driven three-inning matches where every at-bat is one decision (an approach at the plate, a pitch and location on the mound), earn coins, open scout packs, train your players, and raise your team rating. Build the franchise. Create the dynasty. Become a legend.',
+      'An original baseball franchise simulator. Play action three-inning matches where you time your swings at the plate and call your pitches on the mound, earn coins, open scout packs, train your players, and raise your team rating. Build the franchise. Create the dynasty. Become a legend.',
     category: 'Game',
     status: 'Active',
     liveUrl: 'https://diamonddynasty.kluthstudios.com',
@@ -366,8 +366,8 @@ export const PROJECTS: Project[] = [
     studio: 'Kluth Studios',
     highlights: [
       {
-        title: 'One decision per at-bat',
-        body: 'On offense pick an approach (Contact, Power, or Patient); on defense pick one of six pitch types and a location (Attack, Corner, or Waste). Approaches and pitches interact rock-paper-scissors style on top of real player ratings, so every choice matters and none of them takes longer than a breath.',
+        title: 'Time your swings, call your pitches',
+        body: 'Batting is a timing game: the pitch flies in and you swing (tap or press Space) as a gold ring lands on the ball, so perfect timing turns singles into home runs while chasing pitches outside the zone gets you out. On the mound you pick one of six pitch types and a location (Attack, Corner, or Waste) and watch it fly to the plate. Player ratings and pitcher fatigue shade every result.',
       },
       {
         title: 'A bullpen with consequences',
@@ -397,7 +397,7 @@ export const PROJECTS: Project[] = [
       },
       {
         title: 'Play the tutorial',
-        body: 'An interactive How to Play primer opens before your first match, with hands-on batting and pitching demos. Then it is three innings, one decision per at-bat, and coins either way.',
+        body: 'An interactive How to Play primer opens before your first match, including a live batting practice cage. Then it is three innings of timing your swings and calling your pitches, and coins either way.',
       },
       {
         title: 'Build the dynasty',
@@ -405,6 +405,10 @@ export const PROJECTS: Project[] = [
       },
     ],
     updates: [
+      {
+        date: '2026-07-20',
+        text: 'became an action game: time your swings at the plate, watch your called pitches fly, with three selectable music beds.',
+      },
       {
         date: '2026-07-20',
         text: 'gained an in-game interactive tutorial and a one-tap master mute on every screen.',


### PR DESCRIPTION
The game changed substantially since it launched: batting is now a swing-timing minigame (time the gold ring, tap or press Space) and the pitching half animates the called pitch flying to its location. Settings also gained three selectable music beds plus a rally horn and crowd groan. This brings the docs in line.

- `overview.md`, `how-to-play.md`, `gameplay.md`: batting rewritten as timing, pitching as a live animated call
- `tips.md`: approach-mixing tips replaced with timing and zone-discipline habits (now eight)
- `faq.md`: "Do I play every pitch?" rewritten; sound FAQ now lists the three music tracks
- `changelog.md`: dated entry for the gameplay revamp and music tracks
- `projects.ts`: lede, the key-feature highlight, the tutorial getting-started step, and a new updates-feed line
- `guides/how-to-play.md`: Diamond Dynasty jump-in section

Docusaurus build is green; no em/en dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)